### PR TITLE
clip-vg fixes

### DIFF
--- a/clip-vg.cpp
+++ b/clip-vg.cpp
@@ -383,10 +383,11 @@ void chop_path_intervals(MutablePathMutableHandleGraph* graph,
         if (!force_clip) {
             cerr << " in " << chopped_paths << " paths";
         }
+        cerr << endl;        
         if (removed_subpath_count > 0) {
-            cerr << removed_subpath_count << " orphaned subpaths were removed with total " << removed_subpath_base_count << "bp" << endl;
+            cerr << "[clip-vg]: " << removed_subpath_count << " orphaned subpaths were removed with total "
+                 << removed_subpath_base_count << " bases" << endl;
         }
-        cerr << endl;
     }
 }
 

--- a/tests/t/chop.t
+++ b/tests/t/chop.t
@@ -26,7 +26,7 @@ rm -f none.bed chopped-none.gfa orig.gfa
 
 printf "x\t0\t1\n" > ends.bed
 printf "x\t48\t50\n" >> ends.bed
-clip-vg tiny-flat.vg -b ends.bed > chopped-ends.vg
+clip-vg -n tiny-flat.vg -b ends.bed > chopped-ends.vg
 is "$(vg paths -Ev chopped-ends.vg)" "x[1-48]	47" "chopping ends gives subpath in the middle with correct length"
 is "$(vg stats -l chopped-ends.vg | awk '{print $2}')" "47" "chopping ends leaves correct number of bases"
 
@@ -36,7 +36,7 @@ printf "x\t20\t25\n" > bits.bed
 printf "x\t1\t5\n" >> bits.bed
 printf "x\t10\t20\n" >> bits.bed
 printf "x\t40\t49\n" >> bits.bed
-clip-vg tiny-flat.vg -b bits.bed > chopped-bits.vg
+clip-vg -n tiny-flat.vg -b bits.bed > chopped-bits.vg
 vg paths -Ev chopped-bits.vg | sed -e 's/\t/./g' >  bits.paths
 is "$(cat bits.paths | wc -l)" "4" "correct number of paths obtained after merging consectuive intervals"
 is "$(grep 'x\[0-1\].1' bits.paths | wc -l)" "1" "first bit found"
@@ -60,7 +60,7 @@ rm -f all.bed chopped-all.gfa
 
 printf "x\t0\t1\n" > ends.bed
 printf "x\t48\t50\n" >> ends.bed
-clip-vg tiny-rev.vg -b ends.bed > chopped-ends.vg
+clip-vg -n tiny-rev.vg -b ends.bed > chopped-ends.vg
 is "$(vg paths -Ev chopped-ends.vg)" "x[1-48]	47" "chopping ends gives subpath in the middle with correct length"
 is "$(vg stats -l chopped-ends.vg | awk '{print $2}')" "47" "chopping ends leaves correct number of bases"
 
@@ -70,7 +70,7 @@ printf "x\t20\t25\n" > bits.bed
 printf "x\t1\t5\n" >> bits.bed
 printf "x\t10\t20\n" >> bits.bed
 printf "x\t40\t49\n" >> bits.bed
-clip-vg tiny-rev.vg -b bits.bed > chopped-bits.vg
+clip-vg -n tiny-rev.vg -b bits.bed > chopped-bits.vg
 vg paths -Ev chopped-bits.vg | sed -e 's/\t/./g' >  bits.paths
 is "$(cat bits.paths | wc -l)" "4" "correct number of paths obtained after merging consectuive intervals"
 is "$(grep 'x\[0-1\].1' bits.paths | wc -l)" "1" "first bit found"


### PR DESCRIPTION
Apparently, stretches of sequence between masked regions, which apparently have anchors, can get pulled apart and end up as unaligned compenents in the final graph.  This only happens in a couple chromosomes, but adds up to a lot of sequence overall.  `clip-vg` is changed here to catch them and filter them out.  Also add `-u` option, which in hindsight, makes more sense than using a bed -- it just pops out unaligned stretches of more than K bases which is really what we want.  I think. 