### PR TITLE
halUnclip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 rootPath = ./
 include ./include.mk
 
-all : hal2vg clip-vg halRemoveDupes halMergeChroms
+all : hal2vg clip-vg halRemoveDupes halMergeChroms halUnclip
 
 # Note: hdf5 from apt doesn't seem to work for static builds.  It should be installed
 # from source and configured with "--enable-static --disable-shared", then have its
@@ -33,13 +33,17 @@ ifeq ($(shell ldd halMergeChroms | grep "not a dynamic" | wc -l), $(shell ls hal
 else
 	$(error ldd found dnymaic linked dependency in halMergeChroms)
 endif
-
+ifeq ($(shell ldd halUnclip | grep "not a dynamic" | wc -l), $(shell ls halUnclip | wc -l))
+	$(info ldd verified that halUnclip static)
+else
+	$(error ldd found dnymaic linked dependency in halUnclip)
+endif
 
 cleanFast : 
-	rm -f hal2vg hal2vg.o clip-vg clip-vg.o halRemoveDupes halRemoveDupes.o halMergeChroms halMergeChroms.o
+	rm -f hal2vg hal2vg.o clip-vg clip-vg.o halRemoveDupes halRemoveDupes.o halMergeChroms halMergeChroms.o halUnclip halUnclip.o
 
 clean :
-	rm -f hal2vg hal2vg.o clip-vg clip-vg.o halRemoveDupes halRemoveDupes.o halMergeChroms halMergeChroms.o
+	rm -f hal2vg hal2vg.o clip-vg clip-vg.o halRemoveDupes halRemoveDupes.o halMergeChroms halMergeChroms.o halUnclip halUnclip.o
 	cd deps/sonLib && make clean
 	cd deps/pinchesAndCacti && make clean
 	cd deps/hal && make clean
@@ -80,6 +84,12 @@ halMergeChroms.o : halMergeChroms.cpp ${basicLibsDependencies}
 
 halMergeChroms : halMergeChroms.o ${basicLibsDependencies}
 	${cpp} ${CXXFLAGS} -fopenmp -pthread halMergeChroms.o  ${basicLibs}  -o halMergeChroms
+
+halUnclip.o : halUnclip.cpp subpaths.h ${basicLibsDependencies}
+	${cpp} ${CXXFLAGS} -I . halUnclip.cpp -c
+
+halUnclip : halUnclip.o ${basicLibsDependencies} 
+	${cpp} ${CXXFLAGS} -fopenmp -pthread halUnclip.o  ${basicLibs}  -o halUnclip
 
 test :
 	make

--- a/halUnclip.cpp
+++ b/halUnclip.cpp
@@ -405,22 +405,27 @@ static void copy_and_fill(AlignmentConstPtr in_alignment, AlignmentPtr out_align
             }
         }
 
-        //pass 4: fix up the bottom segmments, as the top segments array indexes they point to may have changed
-        if (progress) {
-            cerr << " [pass 4]" << endl;                
-        }
-        BottomSegment* bs;
-        for (out_botit = out_root_genome->getBottomSegmentIterator(); !out_botit->atEnd(); out_botit->toRight()) {
-            bs = out_botit->bseg();
-            hal_index_t ci = bs->getChildIndex(out_child_no);
-            if (ci != NULL_INDEX) {
-                assert(old_to_new_tsai[ci] != NULL_INDEX);
-                bs->setChildIndex(out_child_no, old_to_new_tsai[ci]);
-            }
-        }
-        
         in_alignment->closeGenome(in_genome);
         out_alignment->closeGenome(out_genome);
+
+        //pass 4: fix up the bottom segmments, as the top segments array indexes they point to may have changed
+        if (progress) {
+            cerr << " [pass 4]" << flush;  
+        }
+        out_botit = out_root_genome->getBottomSegmentIterator();
+        for (size_t i = 0; i < num_bottom; ++i) {
+            BottomSegment* out_bs = out_botit->bseg();
+            hal_index_t ci = out_bs->getChildIndex(out_child_no);
+            if (ci != NULL_INDEX) {
+                assert(old_to_new_tsai[ci] != NULL_INDEX);
+                out_bs->setChildIndex(out_child_no, old_to_new_tsai[ci]);
+            }
+            out_botit->toRight();
+        }
+        
+        if (progress) {
+            cerr << " [done]" << endl;
+        }        
     }
 }
 

--- a/halUnclip.cpp
+++ b/halUnclip.cpp
@@ -218,9 +218,12 @@ static unordered_map<string, vector<Sequence::Info>> get_filled_dimensions(Align
     return dim_map;
 }
 
-static void copy_and_fill(AlignmentConstPtr in_alignment, AlignmentPtr out_alignment, const unordered_map<string, size_t>& seq_dims) {
+static void copy_and_fill(AlignmentConstPtr in_alignment, AlignmentPtr out_alignment, const unordered_map<string, size_t>& seq_dims, bool progress) {
 
     // just copy the root
+    if (progress) {
+        cerr << "[halUnclip]: Copying root segments" << endl;
+    }
     const Genome* in_root_genome = in_alignment->openGenome(in_alignment->getRootName());
     Genome* out_root_genome = out_alignment->openGenome(in_alignment->getRootName());
     BottomSegmentIteratorPtr in_botit = in_root_genome->getBottomSegmentIterator();
@@ -242,6 +245,10 @@ static void copy_and_fill(AlignmentConstPtr in_alignment, AlignmentPtr out_align
     vector<string> names = in_alignment->getChildNames(in_alignment->getRootName());
 
     for (const string& name : names) {
+        if (progress) {
+            cerr << "[halUnclip]: Copying segments of " << name << endl;
+        }
+
         const Genome* in_genome = in_alignment->openGenome(name);
         Genome* out_genome = out_alignment->openGenome(name);
         hal_index_t out_child_no = out_root_genome->getChildIndex(out_genome);
@@ -501,7 +508,7 @@ int main(int argc, char** argv) {
     if (progress) {
         cerr << "[halUnclip]: Copying and filling the graph" << endl;
     }
-    copy_and_fill(in_alignment, out_alignment, seq_dims);
+    copy_and_fill(in_alignment, out_alignment, seq_dims, progress);
 
     // add back the fasta sequences
     if (progress) {

--- a/halUnclip.cpp
+++ b/halUnclip.cpp
@@ -310,7 +310,7 @@ static void copy_and_fill(AlignmentConstPtr in_alignment, AlignmentPtr out_align
                      << out_sequence->getTopSegmentIterator()->tseg()->getArrayIndex() << " - "
                      << (out_sequence->getTopSegmentIterator()->tseg()->getArrayIndex() + in_sequence_frag->getNumTopSegments()) << endl;
 #endif
-                for (size_t i = 0; i < in_sequence_frag->getNumTopSegments(); ++i) {
+                for (size_t j = 0; j < in_sequence_frag->getNumTopSegments(); ++j) {
                     out_top->tseg()->setCoordinates(out_sequence->getStartPosition() + cur_pos, frag_top->tseg()->getLength());
                     out_top->tseg()->setParentIndex(frag_top->tseg()->getParentIndex());
                     out_top->tseg()->setParentReversed(frag_top->tseg()->getParentReversed());
@@ -339,6 +339,15 @@ static void copy_and_fill(AlignmentConstPtr in_alignment, AlignmentPtr out_align
                 out_top->tseg()->setBottomParseIndex(NULL_INDEX);
                 cur_pos += out_top->tseg()->getLength();                
                 out_top->toRight();
+            }
+            if (cur_pos != (int64_t)out_sequence->getSequenceLength()) {
+                cerr << "[halUnclip]: sanity check fail for sequence " << name << "." << base_name << ".  The offset after conversion is "
+                     << cur_pos << " which is different than the sequence length of " << out_sequence->getSequenceLength() << endl
+                     << "[halUnclip]: the fragments are\n";
+                for (size_t i = 0; i < frags.size(); ++i) {
+                    const Sequence* in_sequence_frag = frags[i];
+                    cerr << "     " << in_sequence_frag->getName() << " len=" << in_sequence_frag->getSequenceLength() << endl;                    
+                }
             }
             assert(cur_pos == (int64_t)out_sequence->getSequenceLength());
 

--- a/halUnclip.cpp
+++ b/halUnclip.cpp
@@ -426,12 +426,14 @@ void add_fasta_sequences(AlignmentConstPtr in_alignment, AlignmentPtr out_alignm
     }
 
     string buffer;
+    set<string> done_set;
     while (getline(seqfile, buffer)) {
         vector<string> toks = split_delims(buffer, " \t");
         if (toks.size() == 2) {
             string name = toks[0];
             string fa_path = toks[1];
             if (target_set.count(name)) {
+                done_set.insert(name);
                 if (progress) {
                     cerr << "[halUnclip]: Loading fasta for " << name << " ... " << flush;
                 }
@@ -457,7 +459,7 @@ void add_fasta_sequences(AlignmentConstPtr in_alignment, AlignmentPtr out_alignm
     vector<string> names = in_alignment->getChildNames(in_alignment->getRootName());
     names.push_back(in_alignment->getRootName());
     for (const string& name : names) {
-        if (!target_set.count(name)) {
+        if (!done_set.count(name)) {
             if (progress) {
                 cerr << "[halUnclip]: Directly copying dna strings for " << name << endl;
             };

--- a/halUnclip.cpp
+++ b/halUnclip.cpp
@@ -282,9 +282,11 @@ static void copy_and_fill(AlignmentConstPtr in_alignment, AlignmentPtr out_align
                 // any, so those coordinates can go directly
                 TopSegmentIteratorPtr frag_top = in_sequence_frag->getTopSegmentIterator();
                 int64_t out_top_offset = out_top->tseg()->getArrayIndex();
+#ifdef debug
                 cerr << "frag " << in_sequence_frag->getFullName() << " has " << in_sequence_frag->getNumTopSegments() << " topsegs which will map to range "
                      << out_sequence->getTopSegmentIterator()->tseg()->getArrayIndex() << " - "
                      << (out_sequence->getTopSegmentIterator()->tseg()->getArrayIndex() + in_sequence_frag->getNumTopSegments()) << endl;
+#endif
                 for (size_t i = 0; i < in_sequence_frag->getNumTopSegments(); ++i) {
                     out_top->tseg()->setCoordinates(out_sequence->getStartPosition() + cur_pos, frag_top->tseg()->getLength());
                     out_top->tseg()->setParentIndex(frag_top->tseg()->getParentIndex());
@@ -391,6 +393,17 @@ static void validate_alignments(AlignmentConstPtr in_alignment, AlignmentPtr out
             in_topit->getString(s1);
             out_topit->getString(s2);
             assert(s1 == s2);
+
+            string in_seq_name = in_topit->tseg()->getSequence()->getName();
+            string out_seq_name = out_topit->tseg()->getSequence()->getName();
+            int64_t start;
+            string in_base_name = parse_subpath_name(in_seq_name, &start);
+            assert(in_base_name == out_seq_name);
+            assert(in_topit->getReversed() == out_topit->getReversed());
+            if (!in_topit->getReversed()) {
+                // punt on reverse check for now
+                assert(in_topit->getStartPosition() + start == out_topit->getStartPosition());
+            }
 
             in_botit->toRight();
             out_botit->toRight();

--- a/halUnclip.cpp
+++ b/halUnclip.cpp
@@ -115,7 +115,7 @@ static unordered_map<string, size_t> get_dimensions_from_seqfile(const string& s
     return seq_map;
 }
 
-static unordered_map<string, vector<Sequence::Info>> get_filled_dimensions(AlignmentConstPtr alignment, const unordered_map<string, size_t>& seq_d, bool progress) {
+static unordered_map<string, vector<Sequence::Info>> get_filled_dimensions(AlignmentConstPtr alignment, unordered_map<string, size_t>& seq_d, bool progress) {
 
     unordered_map<string, vector<Sequence::Info>> dim_map;
 
@@ -151,6 +151,7 @@ static unordered_map<string, vector<Sequence::Info>> get_filled_dimensions(Align
                     cerr << "[halUnclip]: Unable to find sequence (from HAL) " << full_name << " in dimension map from input fasta" << endl;
                     exit(1);
                 }
+                seq_d[full_name] = fa_len;
             } else {
                 fa_len = seq_d.at(full_name);
             }

--- a/halUnclip.cpp
+++ b/halUnclip.cpp
@@ -282,10 +282,10 @@ static void copy_and_fill(AlignmentConstPtr in_alignment, AlignmentPtr out_align
             TopSegmentIteratorPtr out_top = out_sequence->getTopSegmentIterator();
             
             int64_t cur_pos = 0;
-            int64_t frag_start = -1;
             vector<const Sequence*>& frags = nf.second;
             for (size_t i = 0; i < frags.size(); ++i) {
                 const Sequence* in_sequence_frag = frags[i];
+                int64_t frag_start = -1;
                 if (target_set.count(name)) {
                     parse_subpath_name(in_sequence_frag->getName(), &frag_start);
                 }
@@ -294,11 +294,17 @@ static void copy_and_fill(AlignmentConstPtr in_alignment, AlignmentPtr out_align
                 }
                 if (frag_start > cur_pos + 1) {
                     // need to add a gap *before* this fragment                    
-                    out_top->tseg()->setCoordinates(cur_pos, out_sequence->getStartPosition() + frag_start - cur_pos);
+                    out_top->tseg()->setCoordinates(cur_pos + out_sequence->getStartPosition(), frag_start - cur_pos);
                     out_top->tseg()->setParentIndex(NULL_INDEX);
                     out_top->tseg()->setNextParalogyIndex(NULL_INDEX);
                     out_top->tseg()->setBottomParseIndex(NULL_INDEX);
+#ifdef debug
+                    cerr << "cur_pos=" << cur_pos << flush;
+#endif
                     cur_pos += out_top->tseg()->getLength();
+#ifdef debug
+                    cerr << " after adding start gap cur_pos=" << cur_pos << " (frag " << i << " name=" << in_sequence_frag->getName() << " fragstart=" << frag_start << ")" << endl;
+#endif
                     out_top->toRight();
                 }
                 // copy the fragment.  note that the ancestor coordinates haven't changed
@@ -325,8 +331,13 @@ static void copy_and_fill(AlignmentConstPtr in_alignment, AlignmentPtr out_align
                         out_botit->bseg()->setChildReversed(out_child_no, out_top->tseg()->getParentReversed());
                     }
                     out_top->tseg()->setBottomParseIndex(NULL_INDEX);
-                    
-                    cur_pos += out_top->tseg()->getLength();         
+#ifdef debug
+                    cerr << "cur_pos=" << cur_pos << flush;
+#endif
+                    cur_pos += out_top->tseg()->getLength();
+#ifdef debug
+                    cerr << " after adding frag " << j << " cur_pos=" << cur_pos << endl;
+#endif
                     frag_top->toRight();
                     out_top->toRight();
                 }            
@@ -337,7 +348,13 @@ static void copy_and_fill(AlignmentConstPtr in_alignment, AlignmentPtr out_align
                 out_top->tseg()->setParentIndex(NULL_INDEX);
                 out_top->tseg()->setNextParalogyIndex(NULL_INDEX);
                 out_top->tseg()->setBottomParseIndex(NULL_INDEX);
-                cur_pos += out_top->tseg()->getLength();                
+#ifdef debug
+                cerr << "cur_pos="<< cur_pos << flush;
+#endif
+                cur_pos += out_top->tseg()->getLength();
+#ifdef debug
+                cerr << " after adding end gap cur_pos=" << cur_pos << endl;
+#endif
                 out_top->toRight();
             }
             if (cur_pos != (int64_t)out_sequence->getSequenceLength()) {

--- a/halUnclip.cpp
+++ b/halUnclip.cpp
@@ -34,7 +34,7 @@ static void initParser(CLParser* optionsParser) {
                                  false);
     optionsParser->addOptionFlag("validate",
                                  "run a (non-exhaustive) check on the output",
-                                 false);    
+                                 false);
     optionsParser->setDescription("Fill back clipped sequence (removed by cactus-preprocess) using the original fasta files"
         ". Star trees only");
 }
@@ -147,10 +147,13 @@ static unordered_map<string, vector<Sequence::Info>> get_filled_dimensions(Align
             string full_name = genome->getName() + "." + parsed_name;
             size_t fa_len = sequence->getSequenceLength();
             if (!seq_d.count(full_name)) {
-                cerr << "[halUnclip]: Unable to find sequence (from HAL) " << full_name << " in dimension map from input fasta" << endl;
-                exit(1);
+                if (parsed_name != sequence_name) {
+                    cerr << "[halUnclip]: Unable to find sequence (from HAL) " << full_name << " in dimension map from input fasta" << endl;
+                    exit(1);
+                }
+            } else {
+                fa_len = seq_d.at(full_name);
             }
-            fa_len = seq_d.at(full_name);
             if (parsed_name == sequence_name && sequence->getSequenceLength() != fa_len) {
                 cerr << "[halUnclip]: Sequence " << full_name << " has len=" << fa_len << " in fasta but len=" << sequence->getSequenceLength() << " in hal" << endl;
                 exit(1);

--- a/halUnclip.cpp
+++ b/halUnclip.cpp
@@ -76,11 +76,35 @@ static unordered_map<string, pair<size_t, string>> read_fasta(const string& fa_p
 
     fastaRead(fa_file, seqs, seq_lens, seq_names);
 
+    // todo: should be done once, but sonlib fasta reading so slow it odesn't matter
+    vector<unsigned char> cmap(numeric_limits<unsigned char>::max());
+    for (unsigned char i = 0; i < cmap.size(); ++i) {
+        switch (i) {
+        case 'a':
+        case 'c':
+        case 'g':
+        case 't':
+        case 'A':
+        case 'C':
+        case 'G':
+        case 'T':
+            cmap[i] = i;
+            break;
+        default:
+            cmap[i] = 'N';
+            break;
+        }
+    }
+
     unordered_map<string, pair<size_t, string>> fa_info; 
     for (int64_t i = 0; i < seqs->length; ++i) {
         string name = (char*)seq_names->list[i];
         size_t len = (size_t)listGetInt(seq_lens, i);
         string seq = (char*)seqs->list[i];
+        for (size_t j = 0; j < seq.length(); ++j) {
+            // hal doesn't like non-acgtn characters
+            seq[j] = cmap[seq[j]];
+        }
         fa_info[name] = make_pair(len, seq);
     }
 

--- a/halUnclip.cpp
+++ b/halUnclip.cpp
@@ -329,16 +329,14 @@ static void copy_and_fill(AlignmentConstPtr in_alignment, AlignmentPtr out_align
 #endif
                     out_top->toRight();
                 }
-                // copy the fragment.  note that the ancestor coordinates haven't changed
-                // any, so those coordinates can go directly
-                TopSegmentIteratorPtr frag_top = in_sequence_frag->getTopSegmentIterator();
 #ifdef debug
                 cerr << "frag " << in_sequence_frag->getFullName() << " has " << in_sequence_frag->getNumTopSegments() << " topsegs which will map to range "
                      << out_sequence->getTopSegmentIterator()->tseg()->getArrayIndex() << " - "
                      << (out_sequence->getTopSegmentIterator()->tseg()->getArrayIndex() + in_sequence_frag->getNumTopSegments()) << endl;
 #endif
-                size_t num_top = in_sequence_frag->getNumTopSegments();
-                for (size_t j = 0; j < num_top; ++j) {
+                // copy the fragment.  note that the ancestor coordinates haven't changed
+                // any, so those coordinates can go directly
+                for (TopSegmentIteratorPtr frag_top = in_sequence_frag->getTopSegmentIterator(); !frag_top->atEnd(); frag_top->toRight()) {
                     ts = out_top->tseg();
                     ts->setCoordinates(out_start + cur_pos, frag_top->tseg()->getLength());
                     ts->setParentIndex(frag_top->tseg()->getParentIndex());

--- a/halUnclip.cpp
+++ b/halUnclip.cpp
@@ -1,0 +1,297 @@
+/*
+ * Copyright (C) 2016 by Glenn Hickey (hickey@soe.ucsc.edu)
+ *
+ * Released under the MIT license, see LICENSE.txt
+ */
+
+// Convert clipped sequences (like chr1_sub_110000_22220000) back to their original states
+
+//#define debug
+
+#include <cstdlib>
+#include <cstdlib>
+#include <iostream>
+#include <cassert>
+#include <fstream>
+#include <deque>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "hal.h"
+#include "commonC.h"
+#include "bioioC.h"
+#include "subpaths.h"
+
+using namespace std;
+using namespace hal;
+
+static void initParser(CLParser* optionsParser) {
+    optionsParser->addArgument("inFile", "input HAL file");
+    optionsParser->addArgument("seqFile", "cactus-style seqfile. 1st col=genome name, 2nd col=(original) fasta file.  only local paths supported");
+    optionsParser->addArgument("outFile", "output HAL file");
+    optionsParser->addOptionFlag("progress",
+                                 "show progress",
+                                 false);
+    optionsParser->setDescription("Fill back clipped sequence (removed by cactus-preprocess) using the original fasta files"
+        ". Star trees only");
+}
+
+static vector<string> split_delims(const string &s, const string& delims) {
+    vector<string> elems;
+    size_t start = string::npos;
+    for (size_t i = 0; i < s.size(); ++i) {
+        if (delims.find(s[i]) != string::npos) {
+            if (start != string::npos && i > start) {
+                elems.push_back(s.substr(start, i - start));
+            }
+            start = string::npos;
+        } else if (start == string::npos) {
+            start = i;
+        }
+    }
+    if (start != string::npos && start < s.size()) {
+        elems.push_back(s.substr(start, s.size() - start));
+    }
+    return elems;
+}
+
+// c++ wrapper for sonlib -- load fasta file into memory
+static unordered_map<string, pair<size_t, string>> read_fasta(const string& fa_path) {
+    FILE* fa_file = fopen(fa_path.c_str(), "r");
+    if (!fa_file) {
+        cerr << "Unable to open fastat file: " << fa_path << endl;
+        exit(1);
+    }
+
+    List* seqs = constructEmptyList(0, free);
+    List* seq_lens = constructEmptyList(0, free);
+    List* seq_names = constructEmptyList(0, free);
+
+    fastaRead(fa_file, seqs, seq_lens, seq_names);
+
+    unordered_map<string, pair<size_t, string>> fa_info; 
+    for (int64_t i = 0; i < seqs->length; ++i) {
+        string name = (char*)seq_names->list[i];
+        size_t len = (size_t)listGetInt(seq_lens, i);
+        string seq = (char*)seqs->list[i];
+        fa_info[name] = make_pair(len, seq);
+    }
+
+    destructList(seqs);
+    destructList(seq_lens);
+    destructList(seq_names);
+
+    return fa_info;
+}
+
+// do a pass over the seqfile to get the total lengths of every sequence
+static unordered_map<string, size_t> get_dimensions_from_seqfile(const string& seqfile_path) {
+    unordered_map<string, size_t> seq_map;
+    
+    ifstream seqfile(seqfile_path);
+    if (!seqfile) {
+        cerr << "[halUnclip]: Unable to open seqfile: " << seqfile_path << endl;
+        exit(1);
+    }
+
+    string buffer;
+    while (getline(seqfile, buffer)) {
+        vector<string> toks = split_delims(buffer, " \t");
+        if (toks.size() == 2) {
+            string name = toks[0];
+            string fa_path = toks[1];
+            unordered_map<string, pair<size_t, string>> fa_info = read_fasta(fa_path);
+            for (auto& fi : fa_info) {
+                seq_map[name + "." + fi.first] = fi.second.first;
+            }
+        }
+    }
+    
+    return seq_map;
+}
+
+static unordered_map<string, vector<Sequence::Info>> get_filled_dimensions(AlignmentConstPtr alignment, const unordered_map<string, size_t>& seq_d, bool progress) {
+
+    unordered_map<string, vector<Sequence::Info>> dim_map;
+
+    
+    vector<string> names = alignment->getChildNames(alignment->getRootName());
+    names.push_back(alignment->getRootName());
+
+    for (const string& name : names) {
+        const Genome* genome = alignment->openGenome(name);
+        vector<Sequence::Info>&  dimensions = dim_map[name];
+        if (progress) {
+            cerr << "[halUnclip]: Scanning dimensions of genome " << genome->getName() << endl;
+        }
+
+        // map base name to sequence fragments
+        unordered_map<string, vector<const Sequence*>> frag_map;
+
+        // pass 1, map all hal sequences back to their base name and check that they correspond to a fasta sequence
+        for (SequenceIteratorPtr seqIt = genome->getSequenceIterator(); not seqIt->atEnd(); seqIt->toNext()) {
+            const Sequence *sequence = seqIt->getSequence();
+            string sequence_name = sequence->getName();
+            string parsed_name = parse_subpath_name(sequence_name);
+            string full_name = genome->getName() + "." + parsed_name;
+            size_t fa_len = sequence->getSequenceLength();
+            if (name != alignment->getRootName()) {
+                if (!seq_d.count(full_name)) {
+                    cerr << "[halUnclip]: Unable to find sequence (from HAL) " << full_name << " in dimension map from input fasta" << endl;
+                    exit(1);
+                }
+                fa_len = seq_d.at(full_name);
+            }
+            if (parsed_name == sequence_name && sequence->getSequenceLength() != fa_len) {
+                cerr << "[halUnclip]: Sequence " << full_name << " has len=" << fa_len << " in fasta but len=" << sequence->getSequenceLength() << " in hal" << endl;
+                exit(1);
+            }
+            if (parsed_name != sequence_name && sequence->getSequenceLength() > fa_len) {
+                cerr << "[halUnclip]: Sequence " << sequence->getFullName() << " has len=" << fa_len << " in fasta but len=" << sequence->getSequenceLength() << " in hal" << endl;
+                exit(1);
+            }
+
+            frag_map[parsed_name].push_back(sequence);
+        }
+
+        // pass 2: compute the dimensions for each base sequence
+        for (auto& nf : frag_map) {
+            const string& base_name = nf.first;
+            string full_name = genome->getName() + "." + base_name;
+            vector<const Sequence*>& frags = nf.second;
+            size_t fa_len;
+            if (name == alignment->getRootName()) {
+                assert(frags.size() == 1);
+                fa_len = frags[0]->getSequenceLength();
+            } else {
+                fa_len = seq_d.at(full_name);
+            }
+            // sort the fragments by start position
+            map<size_t, const Sequence*> start_to_frag;
+            for (const Sequence* frag : frags) {
+                int64_t start;
+                string parsed_name = parse_subpath_name(frag->getName(), &start);
+                if (start == -1) {
+                    start = 0;
+                    assert(frags.size() == 1);
+                }
+                start_to_frag[start] = frag;
+            }
+
+            // count the top segments
+            size_t top = 0;
+            // count the gaps (separate counter just for debugging)
+            size_t gaps = 0;
+            if (start_to_frag.begin()->first > 0) {
+                // gap in front
+                ++gaps;
+            }
+            for (auto i = start_to_frag.begin(); i != start_to_frag.end(); ++i) {
+                auto next = i;
+                ++next;
+                if (next != start_to_frag.end()) {
+                    if (i->first + i->second->getSequenceLength() < next->first) {
+                        // gap in middle
+                        ++gaps;
+                    }
+                }
+                top += i->second->getNumTopSegments();                
+            }
+            if (start_to_frag.rbegin()->first + start_to_frag.rbegin()->second->getSequenceLength() < fa_len) {
+                // gap in back
+                ++gaps;
+            }
+            if (name == alignment->getRootName()) {
+                dimensions.push_back(Sequence::Info(base_name, fa_len, 0, frags[0]->getNumBottomSegments()));
+            } else {
+                dimensions.push_back(Sequence::Info(base_name, fa_len, top + gaps, 0));
+            }
+        }
+        
+        alignment->closeGenome(genome);
+    }
+
+    return dim_map;
+}
+
+static void copy_and_fill(AlignmentConstPtr in_alignment, AlignmentPtr out_alignment, const unordered_map<string, size_t>& seq_dims) {
+
+    // root gets the same dimensions
+    // 
+    
+}
+
+    
+int main(int argc, char** argv) {
+    CLParser optionsParser(WRITE_ACCESS);
+    initParser(&optionsParser);
+    string in_hal_path;
+    string out_hal_path;
+    string seqfile_path;
+    bool progress;
+    try {
+        optionsParser.parseOptions(argc, argv);
+        in_hal_path = optionsParser.getArgument<string>("inFile");
+        seqfile_path = optionsParser.getArgument<string>("seqFile");
+        out_hal_path = optionsParser.getArgument<string>("outFile");
+        progress = optionsParser.getFlag("progress");
+    }
+    catch(exception& e) {
+        cerr << e.what() << endl;
+        optionsParser.printUsage(cerr);
+        exit(1);
+    }
+
+    // load the input genome
+    if (progress) {
+        cerr << "[halUnclip]: Opening input alignment" << endl;
+    }
+    AlignmentConstPtr in_alignment(openHalAlignment(in_hal_path, &optionsParser, READ_ACCESS));
+
+    // and the output genome
+    if (progress) {
+        cerr << "[halUnclip]: Creating output alignment object" << endl;
+    }    
+    AlignmentPtr out_alignment(openHalAlignment(out_hal_path, &optionsParser, READ_ACCESS | WRITE_ACCESS | CREATE_ACCESS));
+
+    // and load the fasta sequence sizes from the seqfile
+    if (progress) {
+        cerr << "[halUnclip]: Reading fasta dimensions from seqfile" << endl;
+    }
+    unordered_map<string, size_t> seq_dims = get_dimensions_from_seqfile(seqfile_path);
+
+    if (progress) {
+        cerr << "[halUnclip]: Computing new hal dimensions" << endl;
+    }
+    unordered_map<string, vector<Sequence::Info>> dimensions = get_filled_dimensions(in_alignment, seq_dims, progress);
+
+    // set up the size of each genome, staring with the root
+    string root_name = in_alignment->getRootName();
+    Genome* root_genome = out_alignment->addRootGenome(root_name);
+    root_genome->setDimensions(dimensions.at(root_name));
+    for (auto& kv : dimensions) {
+        if (kv.first != root_name) {
+            Genome* leaf_genome = out_alignment->addLeafGenome(kv.first, root_name, 1);
+            leaf_genome->setDimensions(kv.second);
+        }
+    }
+    
+    // copy over the filled graph
+    if (progress) {
+        cerr << "[halUnclip]: Copying and filling the graph" << endl;
+    }
+    copy_and_fill(in_alignment, out_alignment, seq_dims);
+
+    // add back the fasta sequences
+    if (progress) {
+        cerr << "[halUnclip]: Adding fasta sequences" << endl;
+    }    
+    //add_fasta_sequences(out_alignment, seqfile_path);
+
+    if (progress) {
+        cerr << "[halUnclip]: Writing output alignment" << endl;
+    }
+     
+    return 0;
+}
+

--- a/halUnclip.cpp
+++ b/halUnclip.cpp
@@ -336,7 +336,9 @@ static void copy_and_fill(AlignmentConstPtr in_alignment, AlignmentPtr out_align
 #endif
                 // copy the fragment.  note that the ancestor coordinates haven't changed
                 // any, so those coordinates can go directly
-                for (TopSegmentIteratorPtr frag_top = in_sequence_frag->getTopSegmentIterator(); !frag_top->atEnd(); frag_top->toRight()) {
+                TopSegmentIteratorPtr frag_top = in_sequence_frag->getTopSegmentIterator();
+                size_t frag_top_count = in_sequence_frag->getNumTopSegments();
+                for (size_t frag_top_i = 0; frag_top_i < frag_top_count; ++frag_top_i) {
                     ts = out_top->tseg();
                     ts->setCoordinates(out_start + cur_pos, frag_top->tseg()->getLength());
                     ts->setParentIndex(frag_top->tseg()->getParentIndex());
@@ -361,7 +363,7 @@ static void copy_and_fill(AlignmentConstPtr in_alignment, AlignmentPtr out_align
 #endif
                     cur_pos += ts->getLength();
 #ifdef debug
-                    cerr << " after adding frag " << j << " cur_pos=" << cur_pos << endl;
+                    cerr << " after adding frag_ts " << frag_top_i << " cur_pos=" << cur_pos << endl;
 #endif
                     frag_top->toRight();
                     out_top->toRight();
@@ -392,8 +394,8 @@ static void copy_and_fill(AlignmentConstPtr in_alignment, AlignmentPtr out_align
                     cerr << "     " << in_sequence_frag->getName() << " len=" << in_sequence_frag->getSequenceLength() << endl;                    
                 }
             }
-            assert(cur_pos == (int64_t)out_sequence->getSequenceLength());
-
+            assert(cur_pos == (int64_t)out_sequence->getSequenceLength());            
+            assert(out_top->getArrayIndex() == out_sequence->getTopSegmentIterator()->getArrayIndex() + (int64_t)out_sequence->getNumTopSegments());
         }
 
         //pass 3: set the paralogy indexes

--- a/halUnclip.cpp
+++ b/halUnclip.cpp
@@ -84,6 +84,8 @@ static unordered_map<string, pair<size_t, string>> read_fasta(const string& fa_p
     destructList(seq_lens);
     destructList(seq_names);
 
+    fclose(fa_file);
+
     return fa_info;
 }
 

--- a/subpaths.h
+++ b/subpaths.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <string>
+#include <sstream>
+#include <cassert>
+
+inline std::string parse_subpath_name(const std::string& path_name, int64_t* out_start = nullptr, int64_t* out_end = nullptr) {
+
+    std::string base_name = path_name;
+    if (out_start) {
+        *out_start = -1;
+    }
+    if (out_end) {
+        *out_end = -1;
+    }
+    
+    size_t first_length = 0;
+    size_t start_offset = 0;
+    while (true) {
+        size_t sp = base_name.rfind("_sub_");
+        if (sp != std::string::npos) {
+            size_t up = base_name.rfind("_");
+            if (up != std::string::npos && up > sp + 1) {
+                int64_t start;
+                int64_t end;
+                try {
+                    start = stol(base_name.substr(sp + 5, up - sp - 5));
+                    end = stol(base_name.substr(up + 1));
+                } catch (...) {
+                    return base_name;
+                }
+                std::stringstream new_name;
+                start_offset += start; // final offset is sum of all nested offsets
+                if (first_length == 0) {
+                    first_length = end - start;
+                    assert(first_length > 0);
+                } else {
+                    // in the case of nested subpaths, the end coordinate will always
+                    // be derived from the start, plus the length of the "top" path
+                    end = start_offset + first_length;
+                }
+                if (out_start) {
+                    *out_start = start_offset;
+                }
+                if (out_end) {
+                    *out_end = end;
+                }
+                base_name = base_name.substr(0, sp);
+            }
+        } else {
+            break;
+        }
+    }
+    return base_name;
+}
+
+inline void resolve_subpath_naming(std::string& path_name) {
+    int64_t sub_start;
+    int64_t sub_end;
+    std::string new_name = parse_subpath_name(path_name, &sub_start, &sub_end);
+    if (sub_start != -1) {
+        assert(new_name != path_name);
+        path_name = new_name + "[" + std::to_string(sub_start) + "-" + std::to_string(sub_end) + "]";
+    }
+}
+


### PR DESCRIPTION
`halUnclip` is a tool to add sequence back to hal files in the event that they were clipped out via `cactus-preprocess`.

It transforms a set of sequence fragments of the form, ex, `chr1_sub_1_10`, `chr1_sub_500_600`, `chr1_sub_1000_20000` and a fasta sequence of the entire `chr1` and makes an output with just `chr1` in it. 

All alignments are preserved, it's just the names and sequence strings that are changed.  New sequence added is by definition unaligned to anything.    