### PR TITLE
Rewrite filter-paf-deletions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ halUnclip.o : halUnclip.cpp subpaths.h ${basicLibsDependencies}
 halUnclip : halUnclip.o ${basicLibsDependencies} 
 	${cpp} ${CXXFLAGS} -fopenmp -pthread halUnclip.o  ${basicLibs}  -o halUnclip
 
-filter-paf-deletions.o : filter-paf-deletions.cpp subpaths.h ${basicLibsDependencies}
+filter-paf-deletions.o : filter-paf-deletions.cpp subpaths.h paf.hpp ${basicLibsDependencies}
 	${cpp} ${CXXFLAGS} -I . filter-paf-deletions.cpp -c
 
 filter-paf-deletions : filter-paf-deletions.o ${basicLibsDependencies} 

--- a/build-tools/makeBinRelease
+++ b/build-tools/makeBinRelease
@@ -39,5 +39,5 @@ else
 	 make check-static
 fi
 
-cp hal2vg clip-vg halRemoveDupes halMergeChroms halUnclip ${buildDir}/
+cp hal2vg clip-vg halRemoveDupes halMergeChroms halUnclip filter-paf-deletions ${buildDir}/
 

--- a/paf.hpp
+++ b/paf.hpp
@@ -74,6 +74,6 @@ inline ostream& operator<<(ostream& os, const PafLine& paf) {
     os << paf.query_name << "\t" << paf.query_len << "\t" << paf.query_start << "\t" << paf.query_end << "\t"
        << string(1, paf.strand) << "\t"
        << paf.target_name << "\t" << paf.target_len << "\t" << paf.target_start << "\t" << paf.target_end << "\t"
-       << paf.num_matching << "\t" << paf.mapq;
+       << paf.num_matching << "\t" << paf.num_bases << "\t" << paf.mapq;
     return os;
 }

--- a/paf.hpp
+++ b/paf.hpp
@@ -75,4 +75,5 @@ inline ostream& operator<<(ostream& os, const PafLine& paf) {
        << string(1, paf.strand) << "\t"
        << paf.target_name << "\t" << paf.target_len << "\t" << paf.target_start << "\t" << paf.target_end << "\t"
        << paf.num_matching << "\t" << paf.mapq;
+    return os;
 }

--- a/paf.hpp
+++ b/paf.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <iostream>
+
+using namespace std;
+
+struct PafLine {
+    string query_name;
+    int64_t query_len;
+    int64_t query_start;
+    int64_t query_end;
+    char strand;
+    string target_name;
+    int64_t target_len;
+    int64_t target_start;
+    int64_t target_end;
+    int64_t num_matching;
+    int64_t num_bases;
+    int64_t mapq;
+    string cigar;
+};
+
+inline vector<string> split_delims(const string &s, const string& delims, vector<string> &elems) {
+    size_t start = string::npos;
+    for (size_t i = 0; i < s.size(); ++i) {
+        if (delims.find(s[i]) != string::npos) {
+            if (start != string::npos && i > start) {
+                elems.push_back(s.substr(start, i - start));
+            }
+            start = string::npos;
+        } else if (start == string::npos) {
+            start = i;
+        }
+    }
+    if (start != string::npos && start < s.size()) {
+        elems.push_back(s.substr(start, s.size() - start));
+    }
+    return elems;
+}
+
+inline PafLine parse_paf_line(const string& paf_line) {
+    vector<string> toks;
+    split_delims(paf_line, "\t\n", toks);
+    assert(toks.size() > 12);
+
+    PafLine paf;
+    paf.query_name = toks[0];
+    paf.query_len = stol(toks[1]);
+    paf.query_start = stol(toks[2]);
+    paf.query_end = stol(toks[3]);
+    assert(toks[4] == "+" || toks[4] == "-");
+    paf.strand = toks[4][0];
+    paf.target_name = toks[5];
+    paf.target_len = stol(toks[6]);
+    paf.target_start = stol(toks[7]);
+    paf.target_end = stol(toks[8]);
+    paf.num_matching = stol(toks[9]);
+    paf.num_bases = stol(toks[10]);
+    paf.mapq = stol(toks[11]);
+
+    for (size_t i = 12; i < toks.size(); ++i) {
+        if (toks[i].compare(0, 3, "cg:Z:") == 0) {
+            paf.cigar = toks[i].substr(5);
+            break;
+        }
+    }
+
+    return paf;
+}
+
+inline ostream& operator<<(ostream& os, const PafLine& paf) {
+    os << paf.query_name << "\t" << paf.query_len << "\t" << paf.query_start << "\t" << paf.query_end << "\t"
+       << string(1, paf.strand) << "\t"
+       << paf.target_name << "\t" << paf.target_len << "\t" << paf.target_start << "\t" << paf.target_end << "\t"
+       << paf.num_matching << "\t" << paf.mapq;
+}


### PR DESCRIPTION
This tool is supposed to do a coarse-grained chaining on the minigraph mapping output, with respect to the reference contigs in the graph.  But it was somehow written to assume there was only one reference contig in the input, even though it gets run at genome scale in cactus.  

Anyway, this is a rewrite to make the code simpler and more general:  
* mappings are sorted by query position.
* target sequences are mapped to reference intervals
* runs of query contigs are segmented into blocks that have contiguous (modulo given threshold) target reference intervals
* disjoint blocks are greedily selected based on having least aligned bases and dropped
* process is repeated until nothing disjoint found

The big question is what threshold to use.  10mb seems to work reasonably well.  In general, increasing this trades off recall for precision.  