### PR TITLE
always set haplotype for refsense -- vg 1.50.0 requires it

### DIFF
--- a/hal2vg.cpp
+++ b/hal2vg.cpp
@@ -653,7 +653,7 @@ void pinch_to_handle(const Genome* genome,
         subrange_t subpath = resolve_subpath_naming(parsed_name);
         string parsed_genome_name = genome->getName();
         size_t haplotype = resolve_haplotype_naming(parsed_genome_name);
-        if (sense == PathSense::HAPLOTYPE && haplotype == PathMetadata::NO_HAPLOTYPE) {
+        if (haplotype == PathMetadata::NO_HAPLOTYPE) {
             haplotype = 0;
         }
         // create the path

--- a/tests/small/truth.json
+++ b/tests/small/truth.json
@@ -173,7 +173,7 @@
           "rank": "6"
         }
       ],
-      "name": "cat#3"
+      "name": "cat#0#3"
     },
     {
       "mapping": [
@@ -264,7 +264,7 @@
           "rank": "7"
         }
       ],
-      "name": "chimp#2"
+      "name": "chimp#0#2"
     },
     {
       "mapping": [
@@ -368,7 +368,7 @@
           "rank": "8"
         }
       ],
-      "name": "human#1"
+      "name": "human#0#1"
     }
   ]
 }

--- a/tests/t/chop.t
+++ b/tests/t/chop.t
@@ -8,8 +8,7 @@ PATH=../deps/hal:$PATH
 
 plan tests 18
 
-#vg convert -g chop/tiny-flat.gfa -p > tiny-flat.vg
-vg convert -g chop/tiny-flat.gfa -o > tiny-flat.vg
+vg convert -g chop/tiny-flat.gfa -p > tiny-flat.vg
 printf "x\t0\t100\n" > all.bed
 clip-vg tiny-flat.vg -b all.bed | vg view - | grep -v ^H > chopped-all.gfa
 is "$(cat chopped-all.gfa | wc -l)" 0 "chopping everything clears out the graph"

--- a/tests/t/merge.t
+++ b/tests/t/merge.t
@@ -27,8 +27,8 @@ hal2vg small2.hal | vg mod -O - | vg ids -s - > small2.vg
 hal2vg merged1.hal | vg mod -O - | vg ids -s - > merged1.vg
 vg view small.vg | sort > small.gfa
 vg view small2.vg | sort > small2.gfa
-vg find -x merged1.vg -p cat#3:1 -c 1000 | vg ids -s - | vg view - | sort | sed -e 's/_0//g' | sed -e 's/_1//g' | sed -e "s/cat human chimp/human chimp cat/g" > merged1.comp1.gfa
-vg find -x merged1.vg -p cow#3:1 -c 1000 | vg ids -s - | vg view - | sort | sed -e 's/_0//g' | sed -e 's/_1//g' | sed -e "s/human chimp cow/cow human chimp/g" > merged1.comp2.gfa
+vg find -x merged1.vg -p cat#0#3:1 -c 1000 | vg ids -s - | vg view - | sort | sed -e 's/_0//g' | sed -e 's/_1//g' | sed -e "s/human chimp cat/chimp human cat/g" > merged1.comp1.gfa
+vg find -x merged1.vg -p cow#0#3:1 -c 1000 | vg ids -s - | vg view - | sort | sed -e 's/_0//g' | sed -e 's/_1//g' | sed -e "s/human cow chimp/chimp human cow/g" > merged1.comp2.gfa
 diff small.gfa merged1.comp1.gfa
 is $? 0 "First component of merged graph identical to first input graph"
 diff small2.gfa merged1.comp2.gfa
@@ -60,8 +60,8 @@ hal2vg small2.hal | vg mod -O - | vg ids -s - > small2.vg
 hal2vg merged1.hal | vg mod -O - | vg ids -s - > merged1.vg
 vg view small.vg | sort > small.gfa
 vg view small2.vg | sort > small2.gfa
-vg find -x merged1.vg -p cat#3:1 -c 1000 | vg ids -s - | vg view - | sort | sed -e 's/_0//g' | sed -e 's/_1//g' | sed -e "s/cat human chimp/human chimp cat/g" > merged1.comp1.gfa
-vg find -x merged1.vg -p cow#3:1 -c 1000 | vg ids -s - | vg view - | sort | sed -e 's/_0//g' | sed -e 's/_1//g' | sed -e "s/human chimp cow/cow human chimp/g" > merged1.comp2.gfa
+vg find -x merged1.vg -p cat#0#3:1 -c 1000 | vg ids -s - | vg view - | sort | sed -e 's/_0//g' | sed -e 's/_1//g' | sed -e "s/human chimp cat/chimp human cat/g" > merged1.comp1.gfa
+vg find -x merged1.vg -p cow#0#3:1 -c 1000 | vg ids -s - | vg view - | sort | sed -e 's/_0//g' | sed -e 's/_1//g' | sed -e "s/human cow chimp/chimp human cow/g" > merged1.comp2.gfa
 diff small.gfa merged1.comp1.gfa
 is $? 0 "First component of merged graph identical to first input graph"
 diff small2.gfa merged1.comp2.gfa


### PR DESCRIPTION
If no haplotype was given for a reference path, `hal2vg` just left it as `PathMetadata::NO_HAPLOTYPE`

This worked okay until [vg 1.50.0](https://github.com/vgteam/vg/releases/tag/v1.50.0) when roundtripping such graphs to GFA would lead to
```
	  what():  Reference path must have a sample name
```
See https://ucsc-ci.com/comparativegenomicstoolkit/cactus/-/jobs/48393

Looks like the fault lies with `hal2vg` since from https://github.com/vgteam/libhandlegraph/blob/9c49c797e3949378136539326fa01eb7e473a09d/src/include/handlegraph/path_metadata.hpp#L27-L28 REFERENCE sense paths have a haplotype number. 

This PR just sets the haplotype to 0 if it's not found, same behaviour has for haplotype paths. 