### PR TITLE
use new batch path destroyer to speed up clipping

### DIFF
--- a/count-vg-hap-cov.cpp
+++ b/count-vg-hap-cov.cpp
@@ -16,7 +16,6 @@
 
 #include "bdsg/packed_graph.hpp"
 #include "bdsg/hash_graph.hpp"
-#include "bdsg/odgi.hpp"
 
 using namespace std;
 using namespace handlegraph;
@@ -35,8 +34,6 @@ static unique_ptr<PathHandleGraph> load_graph(istream& graph_stream) {
         graph = new PackedGraph();
     } else if (magic_number == HashGraph().get_magic_number()) {
         graph = new HashGraph();
-    } else if (magic_number == ODGI().get_magic_number()) {
-        graph = new ODGI();
     } else {
         cerr << "Unable to parse input graph with magic number " << magic_number << endl;
         exit(1);

--- a/filter-paf-deletions.cpp
+++ b/filter-paf-deletions.cpp
@@ -20,7 +20,6 @@
 
 #include "bdsg/packed_graph.hpp"
 #include "bdsg/hash_graph.hpp"
-#include "bdsg/odgi.hpp"
 
 #include "IntervalTree.h"
 #include "paf.hpp"
@@ -799,8 +798,6 @@ unique_ptr<MutablePathMutableHandleGraph> load_graph(istream& graph_stream) {
         graph = new PackedGraph();
     } else if (magic_number == HashGraph().get_magic_number()) {
         graph = new HashGraph();
-    } else if (magic_number == ODGI().get_magic_number()) {
-        graph = new ODGI();
     } else {
         cerr << "Unable to parse input graph with magic number " << magic_number << endl;
         exit(1);

--- a/hal2vg.cpp
+++ b/hal2vg.cpp
@@ -19,7 +19,6 @@
 #include "stPinchGraphs.h"
 #include "bdsg/packed_graph.hpp"
 #include "bdsg/hash_graph.hpp"
-#include "bdsg/odgi.hpp"
 #include "hal.h"
 
 using namespace std;
@@ -48,7 +47,7 @@ static void initParser(CLParser* optionsParser) {
                              "comma-separated (no spaces) list of genomes to ignore",
                              "\"\"");
     optionsParser->addOption("outputFormat",
-                             "output graph format in {pg, hg, odgi} [default=pg]",
+                             "output graph format in {pg, hg} [default=pg]",
                              "pg");
     optionsParser->addOption("chop",
                              "chop up nodes in output graph so they are not longer than given length",
@@ -116,8 +115,8 @@ int main(int argc, char** argv) {
         noAncestors = optionsParser.getFlag("noAncestors");
         ignoreGenomes = optionsParser.getOption<string>("ignoreGenomes");
         outputFormat = optionsParser.getOption<string>("outputFormat");
-        if (outputFormat != "pg" && outputFormat != "hg" && outputFormat != "odgi") {
-            throw hal_exception("--outputFormat must be one of {pg, hg, odgi}");
+        if (outputFormat != "pg" && outputFormat != "hg") {
+            throw hal_exception("--outputFormat must be one of {pg, hg}");
         }
         if (ignoreGenomes != "\"\"" && targetGenomes != "\"\"") {
             throw hal_exception("--ignoreGenomes and --targetGenomes options are "
@@ -321,8 +320,6 @@ int main(int argc, char** argv) {
             graph = unique_ptr<MutablePathMutableHandleGraph>(new PackedGraph());
         } else if (outputFormat == "hg") {
             graph = unique_ptr<MutablePathMutableHandleGraph>(new HashGraph());
-        } else if (outputFormat == "odgi") {
-            graph = unique_ptr<MutablePathMutableHandleGraph>(new ODGI());
         } else {
             assert(false);
         }


### PR DESCRIPTION
This at least partially addresses bottlenecks encountered when clipping graphs with high path depth. 