### PR TITLE
put non-reference forwardization behind its own option

### DIFF
--- a/clip-vg.cpp
+++ b/clip-vg.cpp
@@ -30,7 +30,10 @@ void help(char** argv) {
        << "    -m, --min-length N        Only clip paths of length < N" << endl
        << "    -u, --max-unaligned N     Clip out unaligned regions of length > N" << endl
        << "    -a, --anchor PREFIX       If set, consider regions not aligned to a path with PREFIX unaligned (with -u)" << endl
-       << "    -e, --ref-prefix STR      Forwardize (but don't clip) paths whose name begins with STR, along with any node that no path visits forward" << endl
+       << "    -e, --ref-prefix STR      Forwardize (but don't clip) paths whose name begins with STR" << endl
+       << "    -F, --forwardize-nonref   Also forwardize any node that no path visits forward.  Needs -e." << endl
+       << "                              This mints new node ids, so it must not be used on a graph whose" << endl
+       << "                              id space has to stay compatible with one produced earlier." << endl
        << "    -c, --allow-cycle         Do not fail with error when reference cycle detected" << endl
        << "    -f, --force-clip          Don't abort with error if clipped node overlapped by multiple paths" << endl
        << "    -r, --name-replace S1>S2  Replace (first occurrence of) S1 with S2 in all path names" << endl
@@ -91,6 +94,7 @@ int main(int argc, char** argv) {
     int64_t max_unaligned = 0;
     string anchor_prefix;
     string ref_prefix;
+    bool forwardize_nonref = false;
     bool allow_ref_cycles = false;
     size_t input_count = 0;
     bool force_clip = false;
@@ -111,6 +115,7 @@ int main(int argc, char** argv) {
             {"max-unaligned", required_argument, 0, 'u'},
             {"anchor", required_argument, 0, 'a'},
             {"ref-prefix", required_argument, 0, 'e'},
+            {"forwardize-nonref", no_argument, 0, 'F'},
             {"allow-cycle", no_argument, 0, 'c'},
             {"force-clip", no_argument, 0, 'f'},
             {"name-replace", required_argument, 0, 'r'},
@@ -124,7 +129,7 @@ int main(int argc, char** argv) {
 
         int option_index = 0;
 
-        c = getopt_long (argc, argv, "hpb:m:u:a:e:cfnr:d:Lo:",
+        c = getopt_long (argc, argv, "hpb:m:u:a:e:Fcfnr:d:Lo:",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -150,6 +155,9 @@ int main(int argc, char** argv) {
             break;
         case 'e':
             ref_prefix = optarg;
+            break;
+        case 'F':
+            forwardize_nonref = true;
             break;
         case 'c':
             allow_ref_cycles = true;
@@ -201,6 +209,11 @@ int main(int argc, char** argv) {
     if (optind != argc - 1) {
         cerr << "[clip-vg] error: too many arguments" << endl;
         help(argv);
+        return 1;
+    }
+
+    if (forwardize_nonref && ref_prefix.empty()) {
+        cerr << "[clip-vg] error: -F/--forwardize-nonref requires -e/--ref-prefix" << endl;
         return 1;
     }
 
@@ -308,7 +321,9 @@ int main(int argc, char** argv) {
 
     if (!ref_prefix.empty()) {
         forwardize_paths(graph.get(), ref_prefix, allow_ref_cycles, progress);
-        forwardize_nonref_paths(graph.get(), ref_prefix, progress);
+        if (forwardize_nonref) {
+            forwardize_nonref_paths(graph.get(), ref_prefix, progress);
+        }
     }
     
     if (!replace_list.empty()) {

--- a/tests/t/chop.t
+++ b/tests/t/chop.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=./bash-tap
 PATH=..:$PATH
 PATH=../deps/hal/bin:$PATH
 
-plan tests 43
+plan tests 47
 
 # how many steps of a given path still point backwards.  Reports instead of counting if the
 # graph is unusable or the path is missing, so that a crashed run leaving an empty output
@@ -23,6 +23,13 @@ ref_rev_steps() { # $1=graph  $2=path name
 all_rev_steps() { # $1=graph
     if ! vg validate "$1" > /dev/null 2>&1; then echo "invalid-graph"; return; fi
     vg view "$1" | awk '$1=="P" {print $3}' | tr ',' '\n' | grep -c -- '-$'
+}
+
+# the largest node id in the graph.  clip-vg's second invocation in cactus builds the clipped
+# graph and has to stay inside the id space the first one established, so it must never mint one.
+max_node_id() { # $1=graph
+    if ! vg validate "$1" > /dev/null 2>&1; then echo "invalid-graph"; return; fi
+    vg view "$1" | awk '$1=="S" {if ($2+0 > m) m = $2+0} END {print m+0}'
 }
 
 # forwardizing must never alter what the paths spell out
@@ -194,10 +201,22 @@ rm -f nr-cyc.vg nr-cyc-fwd.vg nr-cycm.vg nr-cycm-fwd.vg
 # nothing downstream can flip them, so clip-vg does it here.
 
 vg convert -g chop/nonref-rev.gfa -p > nr-rev.vg
-clip-vg nr-rev.vg -e x > nr-rev-fwd.vg
+clip-vg nr-rev.vg -e x -F > nr-rev-fwd.vg
 is "$?" "0" "a reverse-aligned non-reference contig forwardizes without error"
 is "$(ref_rev_steps nr-rev-fwd.vg samp.ctg)" "0" "nodes no path visits forward are flipped"
 is "$(same_path_seqs nr-rev.vg nr-rev-fwd.vg)" "0" "flipping non-reference nodes preserves path sequence"
+
+# -F mints node ids, so it must stay opt-in: cactus runs clip-vg a second time to build the
+# clipped graph, and that run has to keep the id space of the first one
+clip-vg nr-rev.vg -e x > nr-rev-noF.vg
+is "$(ref_rev_steps nr-rev-noF.vg samp.ctg)" "2" "without -F, nodes no path visits forward are left alone"
+is "$(vg stats -N nr-rev.vg)" "$(vg stats -N nr-rev-noF.vg)" "without -F the node count is unchanged"
+is "$(max_node_id nr-rev.vg)" "$(max_node_id nr-rev-noF.vg)" "without -F no new node ids are minted"
+
+clip-vg nr-rev.vg -F > nr-rev-badF.err 2>&1
+is "$?" "1" "-F without -e is an error"
+
+rm -f nr-rev-noF.vg nr-rev-badF.err
 
 # ... and a prefix matching no path is an error, caught before anything is clipped
 clip-vg nr-rev.vg -e no-such-prefix > nr-rev-none.vg 2> nr-rev-none.err


### PR DESCRIPTION
Forwardizing nodes that no path visits forward mints new node ids: flip_node rewires the node onto a fresh one and destroys the original.  Cactus runs clip-vg twice -- once to build the full graph, which establishes the canonical node id space, and again to build the clipped graph, which has to stay inside that space and may only remove from it.  Adding it to -e broke the second run.

The reference pass has always minted ids the same way, but could never fire on the second run: the reference path is protected from clipping and never dropped, so its steps are identical in both, and the first run has already forwardized them.  The new pass has no such property.  Clipping runs before forwardizing, so removing steps can leave a node reverse-only that was not before; and drop_paths runs after forwardizing, so the first run forwardizes while the _MINIGRAPH_ paths are still there and then deletes them, leaving reverse-only nodes in its own output.  Either way the second run finds work to do and mints ids for it.

So -e goes back to meaning exactly what it did, and the new pass moves to -F, which cactus passes only when building the full graph.  -F without -e is an error rather than a silent no-op.

The tests now assert what actually matters: without -F the node count and the maximum node id are both unchanged, so no id can have been minted.