### PR TITLE
Add -k/--flank to clip-vg: trim the fringe at repeat boundaries

### DIFF
--- a/clip-vg.cpp
+++ b/clip-vg.cpp
@@ -13,6 +13,8 @@
 #include <unordered_map>
 #include <unistd.h>
 #include <getopt.h>
+#include <limits>
+#include <cmath>
 
 #include "bdsg/packed_graph.hpp"
 #include "bdsg/hash_graph.hpp"
@@ -30,6 +32,17 @@ void help(char** argv) {
        << "    -m, --min-length N        Only clip paths of length < N" << endl
        << "    -u, --max-unaligned N     Clip out unaligned regions of length > N" << endl
        << "    -a, --anchor PREFIX       If set, consider regions not aligned to a path with PREFIX unaligned (with -u)" << endl
+       << "    -k, --flank N             Extend each clipped interval outward by up to N bp for as long as" << endl
+       << "                              unaligned sequence stays dense (see -T), using the same test for" << endl
+       << "                              unaligned that -u does.  Removes the fringe left where an aligner" << endl
+       << "                              extended anchors into a repeat but not far enough to be clipped." << endl
+       << "                              N is the main control: inside a repeat the gate seldom closes" << endl
+       << "                              on its own, so the cap is what decides how much goes." << endl
+       << "    -T, --flank-threshold F   Keep extending while more than this fraction of bases are" << endl
+       << "                              unaligned (0-1).  Negative means calibrate against this graph," << endl
+       << "                              which is strongly advisable: how much unaligned sequence a" << endl
+       << "                              pangenome carries varies several-fold between graphs and is" << endl
+       << "                              not predictable from any input property [-1]" << endl
        << "    -e, --ref-prefix STR      Forwardize (but don't clip) paths whose name begins with STR" << endl
        << "    -F, --forwardize-nonref   Also forwardize any node that no path visits forward.  Needs -e." << endl
        << "                              This mints new node ids, so it must not be used on a graph whose" << endl
@@ -47,7 +60,10 @@ void help(char** argv) {
 
 static unordered_map<string, vector<pair<int64_t, int64_t>>> load_bed(istream& bed_stream, const string& ref_prefix);
 static unordered_map<string, vector<pair<int64_t, int64_t>>> find_unaligned(const PathHandleGraph* graph, int64_t max_unaligned,
-                                                                            const string& ref_prefix, const string& anchor_prefix);
+                                                                            const string& ref_prefix, const string& anchor_prefix,
+                                                                            const unordered_set<nid_t>& anchor_nodes);
+static void build_anchor_nodes(const PathHandleGraph* graph, const string& anchor_prefix,
+                               unordered_set<nid_t>& anchor_nodes_out);
 static unique_ptr<MutablePathMutableHandleGraph> load_graph(istream& graph_stream);
 static vector<string> &split_delims(const string &s, const string& delims, vector<string> &elems);
 static void chop_path_intervals(MutablePathMutableHandleGraph* graph,
@@ -66,13 +82,39 @@ static void flip_node(MutablePathMutableHandleGraph* graph, nid_t node_id);
 static vector<unordered_set<nid_t>> weakly_connected_components(const HandleGraph* graph);
 static void drop_paths(MutablePathMutableHandleGraph* graph, const string& drop_prefix, bool leave_aligned, bool progress);
 
+// Is this step aligned?  With an anchor prefix that means the node sits on one of those paths;
+// without one it means some other path visits the node.  find_unaligned uses this to cut intervals
+// and extend_flanks uses it to decide how far to extend them, so they never disagree.
+static bool step_is_aligned(const PathHandleGraph* graph, handle_t handle, path_handle_t path_handle,
+                            const unordered_set<nid_t>& anchor_nodes, bool have_anchor_prefix) {
+    if (anchor_nodes.count(graph->get_id(handle))) {
+        return true;
+    }
+    if (have_anchor_prefix) {
+        return false;
+    }
+    bool aligned = false;
+    graph->for_each_step_on_handle(handle, [&](step_handle_t other) {
+            if (graph->get_path_handle_of_step(other) != path_handle) {
+                aligned = true;
+            }
+            return !aligned;
+        });
+    return aligned;
+}
+
+static void extend_flanks(const PathHandleGraph* graph,
+                          unordered_map<string, vector<pair<int64_t, int64_t>>>& intervals,
+                          int64_t max_flank, double threshold,
+                          const unordered_set<nid_t>& anchor_nodes, bool have_anchor_prefix,
+                          bool progress);
+
 static unordered_map<string, vector<pair<int64_t, int64_t>>> get_path_intervals(const PathHandleGraph* graph);
 
 static unordered_map<string, vector<pair<int64_t, int64_t>>> get_clipped_intervals(
     const unordered_map<string, vector<pair<int64_t, int64_t>>>& input_intervals,
     const unordered_map<string, vector<pair<int64_t, int64_t>>>& output_intervals);
 
-// Create a subpath name (todo: make same function in vg consistent (it only includes start))
 // A path's name with any subrange stripped off, so that an input path and the subpaths clipped
 // out of it share a key.  get_path_name() spells the subrange out as "name[start-end]", which would
 // file every output subpath under a key no input path has.
@@ -88,6 +130,7 @@ static inline string strip_subpath_name(const string& path_name) {
                                           PathMetadata::NO_SUBRANGE);
 }
 
+// Create a subpath name (todo: make same function in vg consistent (it only includes start))
 static inline string make_subpath_name(const string& path_name, size_t offset, size_t length) {
     PathSense sense;
     string sample;
@@ -105,8 +148,13 @@ static inline string make_subpath_name(const string& path_name, size_t offset, s
 int main(int argc, char** argv) {
 
     string bed_path;
+    // shared by find_unaligned and extend_flanks so both agree on what unaligned means
+    unordered_set<nid_t> anchor_nodes;
     int64_t min_length = 0;
     int64_t max_unaligned = 0;
+    int64_t flank = 0;
+    double flank_threshold = -1.;
+    bool flank_threshold_set = false;
     string anchor_prefix;
     string ref_prefix;
     bool forwardize_nonref = false;
@@ -129,6 +177,8 @@ int main(int argc, char** argv) {
             {"min-length", required_argument, 0, 'm'},
             {"max-unaligned", required_argument, 0, 'u'},
             {"anchor", required_argument, 0, 'a'},
+            {"flank", required_argument, 0, 'k'},
+            {"flank-threshold", required_argument, 0, 'T'},
             {"ref-prefix", required_argument, 0, 'e'},
             {"forwardize-nonref", no_argument, 0, 'F'},
             {"allow-cycle", no_argument, 0, 'c'},
@@ -146,7 +196,7 @@ int main(int argc, char** argv) {
 
         int option_index = 0;
 
-        c = getopt_long (argc, argv, "hpb:m:u:a:e:Fcfnr:d:Lo:",
+        c = getopt_long (argc, argv, "hpb:m:u:a:k:T:e:Fcfnr:d:Lo:",
                          long_options, &option_index);
 
         // Detect the end of the options.
@@ -169,6 +219,13 @@ int main(int argc, char** argv) {
             break;
         case 'a':
             anchor_prefix = optarg;
+            break;
+        case 'k':
+            flank = stol(optarg);
+            break;
+        case 'T':
+            flank_threshold = stod(optarg);
+            flank_threshold_set = true;
             break;
         case 'e':
             ref_prefix = optarg;
@@ -243,14 +300,63 @@ int main(int argc, char** argv) {
         cerr <<  "[clip-vg] error: at east one of -b, -m, -u, -e or -r must be specified" << endl;
         return 1;
     }
-    if (!anchor_prefix.empty() && max_unaligned <= 0) {
-        cerr << "[clip-vg] error: -a cannot be used without -u" << endl;
+    if (!anchor_prefix.empty() && max_unaligned <= 0 && flank <= 0) {
+        // -a used to matter only to -u.  It now also picks the test -k extends on, so it is
+        // meaningful alongside -b, where the intervals come from a file but the gate still has to
+        // decide what counts as unaligned.
+        cerr << "[clip-vg] error: -a cannot be used without -u or -k" << endl;
         return 1;
     }
     
     if (leave_aligned_drop_paths && drop_prefix.empty()) {
         cerr << "[clip-vg] error: -L can only be used with -d" << endl;
         return 1;
+    }
+
+    // -0.0 is not less than zero, so it would slip past the "negative means calibrate" test in
+    // extend_flanks() and land on threshold 0 -- the most aggressive setting there is, where a long
+    // node scores 0 rather than negative and the walk can never die on clean sequence.  Python's
+    // str(-0.0) is "-0.0", so a config carrying it reaches us in this form.  Normalise it here.
+    if (std::signbit(flank_threshold)) {
+        flank_threshold = -1.;
+    }
+    if (std::isnan(flank_threshold)) {
+        cerr << "[clip-vg] error: -T/--flank-threshold is not a number.  Every node would score NaN,"
+             << " no comparison against the running maximum would ever be true, and -k would do"
+             << " nothing at all without saying so.  Use a negative value to calibrate." << endl;
+        return 1;
+    }
+    if (flank_threshold >= 1.) {
+        cerr << "[clip-vg] error: -T/--flank-threshold must be less than 1: at 1 or above every"
+             << " node scores negative and no flank is ever trimmed.  Use a negative value to"
+             << " calibrate against the graph." << endl;
+        return 1;
+    }
+
+    // -k reshapes clipped intervals, so it needs a source of them.  -m makes exactly one interval
+    // per path, spanning the whole path, which leaves nothing outside to extend into.  Warn rather
+    // than fail: a wrapper may pass -k unconditionally and turn it off with -k 0, and failing a
+    // multi-hour job over that would be worse.
+    if (flank > 0) {
+        if (input_count == 0) {
+            cerr << "[clip-vg] warning: -k/--flank needs clipped intervals to act on, but none of"
+                 << " -b, -m or -u was given" << endl;
+        } else if (min_length != 0) {
+            cerr << "[clip-vg] warning: -k/--flank has no effect with -m/--min-length, which clips"
+                 << " whole paths" << endl;
+        }
+    }
+    if (flank_threshold_set && flank <= 0) {
+        cerr << "[clip-vg] warning: -T/--flank-threshold only applies with -k/--flank" << endl;
+    }
+    // 0 is in the documented range and is a coherent thing to ask for -- extend unconditionally,
+    // which is the no-gate control -- but it does not read that way, so say what it does.  An
+    // aligned base scores exactly 0 at this threshold rather than negative, so the running total
+    // never falls and the walk cannot die on aligned sequence.
+    if (flank > 0 && flank_threshold == 0.) {
+        cerr << "[clip-vg] warning: -T 0 gates nothing: aligned sequence scores 0 rather than"
+             << " negative, so every trim runs out to the -k cap.  Pass a positive threshold to"
+             << " gate on unaligned density, or a negative one to calibrate." << endl;
     }
 
     string graph_path = argv[optind++];
@@ -264,6 +370,11 @@ int main(int argc, char** argv) {
     if (progress) {
         cerr << "[clip-vg]: Loaded graph" << endl;
     }
+
+    // Both the interval search and the flank gate ask the same question of a node, so build the
+    // table once here.  -k can be used with -b, where find_unaligned never runs, and an empty
+    // table would make every node look unaligned.
+    build_anchor_nodes(graph.get(), anchor_prefix, anchor_nodes);
 
     // Catch a mistyped -e here, before anything has been clipped.  Unaligned regions are measured
     // against the reference, so a prefix that matches no path makes every base look unaligned and
@@ -321,15 +432,53 @@ int main(int argc, char** argv) {
             cerr << "[clip-vg]: Finding unaligned intervals >= " << max_unaligned
                  << " using anchor prefix " << anchor_prefix << " and ref prefix " << ref_prefix << endl;
         }
-        bed_intervals = find_unaligned(graph.get(), max_unaligned, ref_prefix, anchor_prefix);
+        bed_intervals = find_unaligned(graph.get(), max_unaligned, ref_prefix, anchor_prefix,
+                                       anchor_nodes);
     }
     
+    if (flank > 0 && !bed_intervals.empty()) {
+        extend_flanks(graph.get(), bed_intervals, flank, flank_threshold, anchor_nodes,
+                      !anchor_prefix.empty(), progress);
+
+        // Mott's rule walks past a locally aligned stretch when unaligned sequence resumes beyond
+        // it, so two intervals with a short gap between them can each extend across it and end up
+        // overlapping.  chop_path requires sorted disjoint intervals, so collapse those.  Measured
+        // 3 collapses on a 118-haplotype chrY and 93 on chr21, so this is not a corner case.
+        size_t num_overlaps = 0;
+        for (auto& bi : bed_intervals) {
+            vector<pair<int64_t, int64_t>>& intervals = bi.second;
+            if (intervals.size() < 2) {
+                continue;
+            }
+            sort(intervals.begin(), intervals.end());
+            vector<pair<int64_t, int64_t>> merged;
+            merged.push_back(intervals[0]);
+            for (size_t i = 1; i < intervals.size(); ++i) {
+                // Only an actual overlap.  gap == 0 is book-ended, which load_bed has always
+                // accepted and chop_path has always handled -- merging those would drop a
+                // breakpoint and renumber the nodes a plain -b run has always emitted.
+                if (intervals[i].first < merged.back().second) {
+                    ++num_overlaps;
+                    merged.back().second = max(merged.back().second, intervals[i].second);
+                } else {
+                    merged.push_back(intervals[i]);
+                }
+            }
+            swap(intervals, merged);
+        }
+        if (progress && num_overlaps > 0) {
+            cerr << "[clip-vg]: Collapsed " << num_overlaps
+                 << " intervals that -k extended into each other" << endl;
+        }
+    }
+
     if (progress) {
         size_t num_intervals = 0;
         for (auto& bi : bed_intervals) {
             num_intervals += bi.second.size();
         }
-        cerr << "[clip-vg]: Loaded " << num_intervals << " BED intervals over " << bed_intervals.size() << " sequences" << endl;
+        cerr << "[clip-vg]: Clipping " << num_intervals << " intervals over " << bed_intervals.size()
+             << " sequences" << endl;
     }
 
     if (!bed_intervals.empty()) {
@@ -417,23 +566,28 @@ unordered_map<string, vector<pair<int64_t, int64_t>>> load_bed(istream& bed_stre
     return intervals;
 }
 
-unordered_map<string, vector<pair<int64_t, int64_t>>> find_unaligned(const PathHandleGraph* graph, int64_t max_unaligned,
-                                                                     const string& ref_prefix, const string& anchor_prefix) {
-    unordered_map<string, vector<pair<int64_t, int64_t>>> intervals;
-
-    // anchor-prefix means we consider a node unaligned if it doesn't align to a path with that prefix
-    // to do this check, we need a table of nodes on these paths:
-    unordered_set<nid_t> minigraph_nodes;
-    if (!anchor_prefix.empty()) {
-        graph->for_each_path_handle([&](path_handle_t path_handle) {
-                string path_name = graph->get_path_name(path_handle);
-                if (path_name.compare(0, anchor_prefix.length(), anchor_prefix) == 0) {
-                    graph->for_each_step_in_path(path_handle, [&](step_handle_t step_handle) {
-                        minigraph_nodes.insert(graph->get_id(graph->get_handle_of_step(step_handle)));
-                    });
-                }
-            });
+// anchor-prefix means we consider a node unaligned if it doesn't align to a path with that prefix,
+// so we need a table of the nodes on those paths.  Built here rather than inside find_unaligned
+// because -k needs it too, and -k can be given with -b, where find_unaligned never runs.
+void build_anchor_nodes(const PathHandleGraph* graph, const string& anchor_prefix,
+                        unordered_set<nid_t>& anchor_nodes_out) {
+    if (anchor_prefix.empty()) {
+        return;
     }
+    graph->for_each_path_handle([&](path_handle_t path_handle) {
+            string path_name = graph->get_path_name(path_handle);
+            if (path_name.compare(0, anchor_prefix.length(), anchor_prefix) == 0) {
+                graph->for_each_step_in_path(path_handle, [&](step_handle_t step_handle) {
+                    anchor_nodes_out.insert(graph->get_id(graph->get_handle_of_step(step_handle)));
+                });
+            }
+        });
+}
+
+unordered_map<string, vector<pair<int64_t, int64_t>>> find_unaligned(const PathHandleGraph* graph, int64_t max_unaligned,
+                                                                     const string& ref_prefix, const string& anchor_prefix,
+                                                                     const unordered_set<nid_t>& anchor_nodes) {
+    unordered_map<string, vector<pair<int64_t, int64_t>>> intervals;
     
     graph->for_each_path_handle([&](path_handle_t path_handle) {
             string path_name = graph->get_path_name(path_handle);
@@ -443,15 +597,8 @@ unordered_map<string, vector<pair<int64_t, int64_t>>> find_unaligned(const PathH
                 graph->for_each_step_in_path(path_handle, [&](step_handle_t step_handle) {
                         handle_t handle = graph->get_handle_of_step(step_handle);
                         int64_t len = (int64_t)graph->get_length(handle);
-                        bool aligned = minigraph_nodes.count(graph->get_id(handle));
-                        if (!aligned && anchor_prefix.empty()) {
-                            graph->for_each_step_on_handle(handle, [&](step_handle_t step_handle_2) {
-                                if (graph->get_path_handle_of_step(step_handle_2) != path_handle) {
-                                    aligned = true;
-                                }
-                                return !aligned;
-                            });
-                        }
+                        bool aligned = step_is_aligned(graph, handle, path_handle, anchor_nodes,
+                                                       !anchor_prefix.empty());
                         // start an unaligned interval
                         if (start < 0 && aligned == false) {
                             start = offset;
@@ -1233,6 +1380,273 @@ void drop_paths(MutablePathMutableHandleGraph* graph, const string& drop_prefix,
         cerr << "[clip-vg]: Drop prefix removed " << removed_base_count << " bases from " << removed_node_count << " nodes in " << removed_path_count << " paths" << endl;        
     }
 }
+// Extend each clipped interval outward along its path for as long as unaligned sequence stays
+// dense, up to max_flank bp on each side.
+//
+// An aligner that extends an anchor into a repeat leaves a fringe: sequence that never reaches the
+// anchor graph, in runs too short for -u to clip.  So we score each base +(1-threshold) when it
+// is unaligned by the same test that cut the intervals, and -threshold otherwise, walk outward
+// and stop at the furthest point where the running total was at its maximum.  That is Mott's
+// trimming rule: the cut still lands past a locally aligned stretch if unaligned sequence resumes
+// beyond it, but a sustained aligned stretch ends the trim.
+//
+// Two consequences of that rule, both intended, neither obvious.  Aligned sequence inside a walk's
+// reach is removed -- crossing a local dip is the whole point, so an anchored stretch with fringe
+// on the far side of it goes.  And an island between two clipped intervals is approached from both
+// sides, so it survives only if it is wider than the two walks' reach combined, not one walk's.
+// When they do meet, every base between them was claimed by one walk or the other, so collapsing
+// the overlap downstream deletes nothing that was not already scored for deletion.
+void extend_flanks(const PathHandleGraph* graph,
+                   unordered_map<string, vector<pair<int64_t, int64_t>>>& intervals,
+                   int64_t max_flank, double threshold,
+                   const unordered_set<nid_t>& anchor_nodes, bool have_anchor_prefix,
+                   bool progress) {
+    int64_t total_added = 0;
+    size_t num_extended = 0;
+
+    // flatten a path into the length of the node at each step and the offset it starts at
+    auto flatten = [&](path_handle_t path_handle, vector<int64_t>& lengths, vector<int64_t>& offsets,
+                       vector<bool>& unaligned) {
+        lengths.clear();
+        offsets.clear();
+        unaligned.clear();
+        int64_t offset = 0;
+        graph->for_each_step_in_path(path_handle, [&](step_handle_t step_handle) {
+                handle_t handle = graph->get_handle_of_step(step_handle);
+                int64_t len = graph->get_length(handle);
+                offsets.push_back(offset);
+                lengths.push_back(len);
+                unaligned.push_back(!step_is_aligned(graph, handle, path_handle, anchor_nodes,
+                                                     have_anchor_prefix));
+                offset += len;
+            });
+        return offset;
+    };
+
+    if (threshold < 0) {
+        // Calibrate against this graph rather than trusting a fixed number.  Over the 24 human
+        // chromosomes of a 460-haplotype pangenome the near-field fraction ran 0.10 to 0.45 and
+        // the threshold it implies 0.054 to 0.230 -- a 4.3x spread tracking neither haplotype
+        // count nor chromosome size, with chr8 lowest, chr13 highest, and a 118-haplotype chrY
+        // near the bottom.  A constant that gates one of those sensibly fails to gate another at
+        // all.  Compare sequence just outside the clipped intervals against sequence far from any
+        // of them, and put the threshold half way between.
+        //
+        // The two distances only have to bracket the fringe.  Its density decays over tens of kb,
+        // so 5kb is inside it on every graph measured, and 200kb is outside: the far-field
+        // fraction came back between 0.0036 and 0.0128 across those same 24 chromosomes, which is
+        // background even alongside the largest arrays.
+        const int64_t CALIB_NEAR = 5000;
+        const int64_t CALIB_FAR = 200000;
+        // Both samples need to be worth believing, but they are estimating opposite things, so
+        // the floors are on different quantities.  far is establishing that a rate is *low*, which
+        // takes length: at the 0.0036-0.0128 measured above, 100kb carries a few hundred unaligned
+        // bases.  near is pinning down a rate that is large, so what it needs is those bases
+        // themselves -- 500 of them, the same order 100kb of background yields, which at a 10-45%
+        // fringe is a few kb of band rather than 100.  Demanding 100kb of near as well would
+        // refuse any graph with a single clipped interval, where 10kb of band already carries a
+        // perfectly good sample.  They arrive in whole nodes rather than independently, so these
+        // are floors on plausibility, not confidence intervals.
+        const int64_t CALIB_MIN_FAR = 100000;
+        const int64_t CALIB_MIN_NEAR_UNALIGNED = 500;
+        int64_t near_tot = 0, near_unaligned = 0, far_tot = 0, far_unaligned = 0;
+        vector<int64_t> lengths, offsets;
+        vector<bool> unaligned;
+
+        for (auto& pi : intervals) {
+            if (!graph->has_path(pi.first)) {
+                continue;
+            }
+            flatten(graph->get_path_handle(pi.first), lengths, offsets, unaligned);
+            if (lengths.empty()) {
+                continue;
+            }
+            vector<int64_t> edges;
+            for (auto& interval : pi.second) {
+                edges.push_back(interval.first);
+                edges.push_back(interval.second);
+            }
+            sort(edges.begin(), edges.end());
+
+            for (size_t i = 0; i < lengths.size(); ++i) {
+                int64_t mid = offsets[i] + lengths[i] / 2;
+                // The intervals are disjoint and sorted, so edges alternate start,end,start,end...
+                // and a position sits inside one exactly when an odd number of edges precede it.
+                // Skip those -- they are going anyway -- without rescanning every interval.
+                size_t after = upper_bound(edges.begin(), edges.end(), mid) - edges.begin();
+                if (after % 2 == 1) {
+                    continue;
+                }
+                int64_t dist = numeric_limits<int64_t>::max();
+                if (after > 0) {
+                    dist = min(dist, mid - edges[after - 1]);
+                }
+                if (after < edges.size()) {
+                    dist = min(dist, edges[after] - mid);
+                }
+                if (dist <= CALIB_NEAR) {
+                    near_tot += lengths[i];
+                    if (unaligned[i]) near_unaligned += lengths[i];
+                } else if (dist >= CALIB_FAR) {
+                    far_tot += lengths[i];
+                    if (unaligned[i]) far_unaligned += lengths[i];
+                }
+            }
+        }
+
+        double near_frac = near_tot ? (double)near_unaligned / near_tot : 0.;
+        double far_frac = far_tot ? (double)far_unaligned / far_tot : 0.;
+        // An unsampled background is not a clean one.  Left ungated, far_tot == 0 gives far_frac 0
+        // -- the most permissive answer there is -- and the threshold below collapses to
+        // near_frac / 2, which on uniformly unaligned sequence sits under the background rate by
+        // construction: the walk never turns negative and every trim runs to its -k cap over
+        // ordinary sequence.  Nothing reaches the far bucket unless some path runs more than
+        // CALIB_FAR past a clipped interval, which no short contig does, and a handful of far bases
+        // estimates a fraction no better than none of them do.  Demand a real sample or decline.
+        // Both samples get a floor, and the same one.  near_frac sets the threshold directly --
+        // with the background this far below it, threshold is within a few percent of near/2 --
+        // so an unreliable near estimate is at least as damaging as an unreliable far one.
+        if (far_tot < CALIB_MIN_FAR) {
+            cerr << "[clip-vg]: Flank calibration sampled " << far_tot << "bp beyond " << CALIB_FAR
+                 << "bp of a clipped interval and wants " << CALIB_MIN_FAR << "bp: too little"
+                 << " background to estimate an unaligned rate from.  Skipping flank trimming --"
+                 << " pass -T explicitly to trim without calibrating." << endl;
+            return;
+        }
+        if (near_unaligned < CALIB_MIN_NEAR_UNALIGNED) {
+            cerr << "[clip-vg]: Flank calibration found " << near_unaligned << "bp of unaligned"
+                 << " sequence within " << CALIB_NEAR << "bp of a clipped interval and wants "
+                 << CALIB_MIN_NEAR_UNALIGNED << "bp: too little fringe to measure.  Skipping flank"
+                 << " trimming -- pass -T explicitly to trim without calibrating." << endl;
+            return;
+        }
+        // A fringe has to stand out from the background, not merely exceed it.  The guard below
+        // only bounds the sign of the difference, and a graph that is uniformly a few percent
+        // unaligned would pass it and then calibrate to a threshold under its own ambient rate --
+        // at which the walk never turns negative and every trim runs to the -k cap over ordinary
+        // sequence.  Measured separations are 21x to 97x across 24 human chromosomes, so 2x
+        // refuses the pathology without coming close to real data.
+        if (near_frac <= 2. * far_frac) {
+            cerr << "[clip-vg]: Flank calibration found no fringe to speak of (near " << near_frac
+                 << " vs far " << far_frac << ", less than 2x); skipping flank trimming" << endl;
+            return;
+        }
+        threshold = far_frac + 0.5 * (near_frac - far_frac);
+        // Unconditional, like the two refusals above: this number decides how much sequence -k
+        // deletes, it came from the graph rather than the command line, and a run that does not
+        // pass -p still needs it in its log to be reproducible.
+        cerr << "[clip-vg]: Flank calibration: " << near_frac << " of bases unaligned within "
+             << CALIB_NEAR << "bp of a clipped interval vs " << far_frac << " beyond "
+             << CALIB_FAR << "bp; using threshold " << threshold << endl;
+    }
+
+    for (auto& pi : intervals) {
+        if (!graph->has_path(pi.first)) {
+            continue;
+        }
+        path_handle_t path_handle = graph->get_path_handle(pi.first);
+
+        vector<int64_t> lengths;
+        vector<int64_t> offsets;
+        vector<bool> unaligned;
+        int64_t path_length = flatten(path_handle, lengths, offsets, unaligned);
+        if (lengths.empty()) {
+            continue;
+        }
+
+        // The score of one node, in Mott's formulation.  eff is how much of the node counts: the
+        // part of it that lies outside the interval being extended and outside the neighbouring
+        // intervals.  That is the whole node everywhere except at the two ends of a walk.
+        auto node_score = [&](size_t idx, int64_t eff) -> double {
+            return (unaligned[idx] ? (double)eff : 0.0) - threshold * (double)eff;
+        };
+
+        vector<pair<int64_t, int64_t>>& path_intervals = pi.second;
+        int64_t prev_end = 0;
+        for (size_t j = 0; j < path_intervals.size(); ++j) {
+            pair<int64_t, int64_t>& interval = path_intervals[j];
+            // Neither walk may score sequence that is already being clipped.  The intervals are
+            // sorted and disjoint here, and the inside of a neighbour is unaligned by construction
+            // -- that is why it was cut -- so a walk let into one would always find a new maximum
+            // there and drag the boundary across the surviving island in between.  Both bounds are
+            // the neighbours' original edges, so what an interval extends to does not depend on
+            // the order the intervals are visited in.
+            int64_t left_bound = prev_end;
+            int64_t right_bound = j + 1 < path_intervals.size() ? path_intervals[j + 1].first : path_length;
+            // Clamped and monotonic so a bad record below cannot hand the next interval a bound
+            // outside the path.  Identical to interval.second for anything well formed, since the
+            // intervals are sorted and disjoint.
+            prev_end = max(prev_end, min(interval.second, path_length));
+
+            // -b intervals come from a file, and load_bed only rejects strict overlaps: a record
+            // can be empty, inverted, or off the end of the path.  Both walks would repair such a
+            // record into a plausible interval that chop_path then honours, so a typo becomes
+            // deleted sequence -- and for a wholly off-path record it converts an abort into
+            // silent data loss.  Leave anything we cannot reason about exactly as it arrived, and
+            // let the code downstream treat it as it always has.
+            if (interval.first < 0 || interval.second > path_length ||
+                interval.first >= interval.second) {
+                continue;
+            }
+
+            // Walk left over [left_bound, interval.first), nearest node first.  A -b interval can
+            // begin inside a node -- the ones find_unaligned makes never do -- so the first node
+            // scored is whichever holds interval.first - 1, and only its part outside counts.
+            size_t start_idx = lower_bound(offsets.begin(), offsets.end(), interval.first) - offsets.begin();
+            double running = 0., best = 0.;
+            int64_t best_pos = interval.first;
+            for (int64_t i = (int64_t)start_idx - 1; i >= 0; --i) {
+                int64_t from = max(offsets[i], left_bound);
+                int64_t to = min(offsets[i] + lengths[i], interval.first);
+                if (to <= from || interval.first - from > max_flank) {
+                    break;
+                }
+                running += node_score(i, to - from);
+                if (running > best) {
+                    best = running;
+                    best_pos = from;
+                }
+            }
+            if (best_pos < interval.first) {
+                total_added += interval.first - best_pos;
+                ++num_extended;
+                interval.first = best_pos;
+            }
+
+            // and right over (interval.second, right_bound], starting likewise on the node that
+            // holds interval.second when the interval does not end on a boundary
+            size_t end_idx = lower_bound(offsets.begin(), offsets.end(), interval.second) - offsets.begin();
+            if (end_idx > 0 && offsets[end_idx - 1] + lengths[end_idx - 1] > interval.second) {
+                --end_idx;
+            }
+            running = 0.; best = 0.;
+            best_pos = interval.second;
+            for (size_t i = end_idx; i < lengths.size(); ++i) {
+                int64_t from = max(offsets[i], interval.second);
+                int64_t to = min(offsets[i] + lengths[i], right_bound);
+                if (to <= from || to - interval.second > max_flank) {
+                    break;
+                }
+                running += node_score(i, to - from);
+                if (running > best) {
+                    best = running;
+                    best_pos = to;
+                }
+            }
+            if (best_pos > interval.second) {
+                total_added += best_pos - interval.second;
+                ++num_extended;
+                interval.second = best_pos;
+            }
+        }
+    }
+
+    if (progress) {
+        cerr << "[clip-vg]: Extended " << num_extended << " interval ends by " << total_added
+             << " bp of unaligned flank" << endl;
+    }
+}
+
 unordered_map<string, vector<pair<int64_t, int64_t>>> get_path_intervals(const PathHandleGraph* graph) {
     unordered_map<string, vector<pair<int64_t, int64_t>>> path_intervals;
     graph->for_each_path_handle([&](path_handle_t path_handle) {

--- a/tests/t/chop.t
+++ b/tests/t/chop.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=./bash-tap
 PATH=..:$PATH
 PATH=../deps/hal/bin:$PATH
 
-plan tests 52
+plan tests 81
 
 # how many steps of a given path still point backwards.  Reports instead of counting if the
 # graph is unusable or the path is missing, so that a crashed run leaving an empty output
@@ -28,7 +28,9 @@ all_rev_steps() { # $1=graph
 # the largest node id in the graph.  clip-vg's second invocation in cactus builds the clipped
 # graph and has to stay inside the id space the first one established, so it must never mint one.
 max_node_id() { # $1=graph
-    if ! vg validate "$1" > /dev/null 2>&1; then echo "invalid-graph"; return; fi
+    # name the graph in the failure string: two invalid graphs must not compare equal, or an
+    # assertion that both sides are unchanged passes when both sides in fact crashed
+    if ! vg validate "$1" > /dev/null 2>&1; then echo "invalid-graph:$1"; return; fi
     vg view "$1" | awk '$1=="S" {if ($2+0 > m) m = $2+0} END {print m+0}'
 }
 
@@ -273,3 +275,229 @@ clip-vg outbed.vg -f -e REF -a _MINIGRAPH_ -u 50 --no-orphan_filter > /dev/null 
 is "$?" "0" "and the --no-orphan_filter spelling that shipped still works"
 
 rm -f outbed.gfa outbed.vg outbed-sub.vg outbed.bed outbed-clipped.vg
+# --- -k/--flank ------------------------------------------------------------------------------
+
+# Build a synthetic graph from a spec of <count>:<nodelen>:<aligned 0|1> segments.  REF and SAMP
+# run over every node; _MINIGRAPH_ covers only the aligned segments, so -a marks the rest unaligned.
+mkgraph() { # $1=out.gfa  $2=spec
+    awk -v spec="$2" 'BEGIN{
+        print "H\tVN:Z:1.0"
+        nseg=split(spec, S, " "); nid=0; allp=""
+        for (s=1; s<=nseg; s++) {
+            split(S[s], F, ":")
+            for (i=0; i<F[1]; i++) {
+                nid++; seq=""
+                for (j=0; j<F[2]; j++) seq = seq substr("ACGT", (j%4)+1, 1)
+                print "S\t" nid "\t" seq
+                allp = allp (allp=="" ? "" : ",") nid "+"
+                if (F[3]==1) mg[s] = (s in mg) ? mg[s] "," nid "+" : nid "+"
+            }
+        }
+        for (i=1; i<nid; i++) print "L\t" i "\t+\t" (i+1) "\t+\t0M"
+        print "P\tREF#0#chr1\t" allp "\t*"
+        print "P\tSAMP#0#chr1\t" allp "\t*"
+        for (s=1; s<=nseg; s++) if (s in mg) print "P\t_MINIGRAPH_#0#mg" s "\t" mg[s] "\t*"
+    }' > "$1"
+}
+
+# the surviving SAMP fragments, as a sorted list of start-end subranges
+samp_frags() { # $1=graph
+    # name the graph, so two crashed runs never compare equal (see max_node_id)
+    if ! vg validate "$1" > /dev/null 2>&1; then echo "invalid-graph:$1"; return; fi
+    vg paths -E -x "$1" 2>/dev/null | awk '$1 ~ /^SAMP/ {print $1}' \
+        | sed 's/.*\[//; s/\]//' | sort -t- -k1,1n | tr '\n' ' ' | sed 's/ *$//'
+}
+
+# aligned(200) unaligned(500) aligned-island(200) unaligned(500) aligned(200)
+mkgraph island.gfa "2:100:1 5:100:0 2:100:1 5:100:0 2:100:1"
+vg convert -g island.gfa -p > island.vg
+
+clip-vg island.vg -f -e REF -a _MINIGRAPH_ -u 400 > island-u.vg
+is "$(samp_frags island-u.vg)" "0-200 700-900 1400-1600" "an aligned island between two clipped runs survives -u"
+
+# -k stops at that island rather than crossing it: the aligned nodes score negative and no
+# unaligned sequence resumes beyond them before the next clipped interval.
+clip-vg island.vg -f -e REF -a _MINIGRAPH_ -u 400 -k 1000 -T 0.25 > island-k.vg
+is "$(samp_frags island-k.vg)" "0-200 700-900 1400-1600" "-k does not cross an aligned island"
+
+rm -f island.gfa island.vg island-u.vg island-k.vg
+
+# Two clipped runs separated by a gap that is mostly unaligned: aligned(20) unaligned(300)
+# aligned(20).  Mott's rule walks each interval across its near aligned stretch because unaligned
+# sequence resumes beyond it, so both extend into the gap and into each other.  chop_path cannot
+# take overlapping intervals, so they have to be collapsed.
+mkgraph collide.gfa "1:100:1 5:100:0 2:10:1 30:10:0 2:10:1 5:100:0 1:100:1"
+vg convert -g collide.gfa -p > collide.vg
+
+clip-vg collide.vg -f -e REF -a _MINIGRAPH_ -u 400 > collide-u.vg
+is "$(samp_frags collide-u.vg)" "0-100 600-940 1440-1540" "without -k the sub-threshold gap survives"
+
+clip-vg collide.vg -f -e REF -a _MINIGRAPH_ -u 400 -k 1000 -T 0.25 > collide-k.vg
+is "$(samp_frags collide-k.vg)" "0-100 1440-1540" "-k extends two intervals into each other and they collapse"
+
+rm -f collide.gfa collide.vg collide-u.vg collide-k.vg
+
+# clean(400) fringe(390) anchor(10) unaligned(500) anchor(10) fringe(390) clean(400).  The fringe
+# is unaligned too, but in a run of 390 -- under -u 400, so -u leaves it and only -k can reach it.
+mkgraph flank.gfa "2:200:1 39:10:0 1:10:1 5:100:0 1:10:1 39:10:0 2:200:1"
+vg convert -g flank.gfa -p > flank.vg
+
+clip-vg flank.vg -f -e REF -a _MINIGRAPH_ -u 400 > flank-u.vg
+is "$(samp_frags flank-u.vg)" "0-800 1300-2100" "without -k the sub-threshold fringe survives"
+
+clip-vg flank.vg -f -e REF -a _MINIGRAPH_ -u 400 -k 1000 -T 0.25 > flank-k.vg
+is "$(samp_frags flank-k.vg)" "0-400 1700-2100" "-k trims the unaligned fringe and stops at aligned sequence"
+is "$(vg paths -E -x flank-k.vg 2>/dev/null | awk '$1 ~ /^REF/ {print $2}')" "2100" "-k leaves the reference intact"
+is "$(max_node_id flank-u.vg)" "$(max_node_id flank-k.vg)" "-k mints no new node ids"
+
+clip-vg flank.vg -f -e REF -a _MINIGRAPH_ -u 400 -k 100 -T 0.25 > flank-cap.vg
+is "$(samp_frags flank-cap.vg)" "0-700 1400-2100" "-k never trims further than its cap"
+
+rm -f flank.gfa flank.vg flank-u.vg flank-k.vg flank-cap.vg
+
+# A flank only 20% unaligned by base (20bp unaligned against 80bp anchored).  A wholly unaligned
+# flank goes at any threshold below 1, so it takes a mixed one to show that the threshold, rather
+# than the mere presence of unaligned sequence, is what decides how far the trim runs.
+mixed=""
+for i in $(seq 10); do mixed="$mixed 1:20:0 1:80:1"; done
+mkgraph mixed.gfa "2:200:1$mixed 5:100:0$mixed 2:200:1"
+vg convert -g mixed.gfa -p > mixed.vg
+
+# Below the threshold the whole flank goes.  The right edge stops at 2820 rather than 2900 because
+# the trim ends on the last *unaligned* node -- running out over the trailing 80bp one lowers the
+# score -- so the periodic pattern leaves the two sides a phase apart.
+clip-vg mixed.vg -f -e REF -a _MINIGRAPH_ -u 400 -k 2000 -T 0.15 > mixed-lo.vg
+is "$(samp_frags mixed-lo.vg)" "0-400 2820-3300" "-k trims a 20% unaligned flank when the threshold is below it"
+
+# Above it neither side moves at all -- the first node each walk sees is 80bp of anchored sequence,
+# which at this threshold outscores the 20bp of unaligned beyond it.  Assert that against -u alone
+# rather than against a literal, so this stays a statement about -k doing nothing.  (The clipped
+# run is 520bp, not 500: the 5:100:0 block is followed immediately by the next 1:20:0.)
+clip-vg mixed.vg -f -e REF -a _MINIGRAPH_ -u 400 > mixed-none.vg
+clip-vg mixed.vg -f -e REF -a _MINIGRAPH_ -u 400 -k 2000 -T 0.25 > mixed-hi.vg
+is "$(samp_frags mixed-hi.vg)" "$(samp_frags mixed-none.vg)" "-k trims nothing when the threshold is above the flank's density"
+
+# Everything above passes an explicit -T, so the default -- calibrating against the graph -- has
+# never run.  Here unaligned sequence is spread evenly and the graph is only 3300bp long, so no base sits
+# far enough from the clipped interval to measure a background rate from.  With nothing to compare
+# against, calibration has to refuse: treating an unsampled background as a clean one puts the
+# threshold at half the measured rate, which is below that rate by construction, so the walk never
+# turns negative and the trim runs to its -k cap over ordinary sequence.
+clip-vg mixed.vg -f -e REF -a _MINIGRAPH_ -u 400 -k 2000 > mixed-auto.vg 2> mixed-auto.err
+is "$(samp_frags mixed-auto.vg)" "0-1400 1920-3300" "the default -T refuses to trim when it cannot sample a background"
+is "$(grep -c 'too little background' mixed-auto.err)" "1" "and says so without needing -p"
+
+# -0.0 is not less than zero, so an unnormalised "negative means calibrate" test would let it
+# through to threshold 0 -- where a long node scores 0 rather than negative and the walk can never
+# die.  Python's str(-0.0) is "-0.0", so a config can hand us one.
+clip-vg mixed.vg -f -e REF -a _MINIGRAPH_ -u 400 -k 2000 -T -0 > mixed-negzero.vg 2>/dev/null
+is "$(samp_frags mixed-negzero.vg)" "0-1400 1920-3300" "-T -0 calibrates like any other negative, rather than trimming flat out"
+
+rm -f mixed.gfa mixed.vg mixed-lo.vg mixed-hi.vg mixed-none.vg mixed-auto.vg mixed-auto.err mixed-negzero.vg
+
+# The same calibration where there is a background to measure: 300kb of clean 200bp nodes on each
+# side, so sequence beyond the far window really is sampled, and the only unaligned sequence in
+# the graph is the 390bp fringe flanking the clipped interval.  Runs on defaults -- no -T.
+mkgraph calib.gfa "1500:200:1 39:10:0 1:10:1 5:100:0 1:10:1 39:10:0 1500:200:1"
+vg convert -g calib.gfa -p > calib.vg
+
+clip-vg calib.vg -f -e REF -a _MINIGRAPH_ -u 400 -k 5000 > calib-k.vg 2> calib-k.err
+is "$(samp_frags calib-k.vg)" "0-300000 301300-601300" "the default -T trims exactly the fringe when it can sample a background"
+is "$(grep -c 'using threshold 0.039' calib-k.err)" "1" "and reports the threshold it calibrated to"
+
+rm -f calib.gfa calib.vg calib-k.vg calib-k.err
+
+# -b intervals, unlike the -u ones every case above uses, need not begin or end on a node boundary.
+# This graph is a palindrome and the interval is centred on it, both endpoints sitting 50bp inside
+# a clean 1000bp node, so whatever -k trims off one side it must trim off the other.  Scoring the
+# part of the straddled node that lies outside the interval is what keeps the two sides in step;
+# charging the whole node on one side and skipping it entirely on the other does not.
+mkgraph straddle.gfa "1:1000:1 5:20:0 1:1000:1 1:500:0 1:1000:1 5:20:0 1:1000:1"
+vg convert -g straddle.gfa -p > straddle.vg
+straddle_path="$(vg paths -E -x straddle.vg 2>/dev/null | awk '$1 ~ /^SAMP/ {print $1}')"
+printf '%s\t2050\t2650\n' "$straddle_path" > straddle.bed
+
+clip-vg straddle.vg -f -e REF -a _MINIGRAPH_ -b straddle.bed -k 3000 -T 0.2 > straddle-hi.vg
+is "$(samp_frags straddle-hi.vg)" "0-2050 2650-4700" "-k charges the straddled node on both sides, so neither side trims"
+
+clip-vg straddle.vg -f -e REF -a _MINIGRAPH_ -b straddle.bed -k 3000 -T 0.05 > straddle-lo.vg
+is "$(samp_frags straddle-lo.vg)" "0-1000 3700-4700" "-k still trims both flanks, symmetrically, at a lower threshold"
+
+rm -f straddle.gfa straddle.vg straddle.bed straddle-hi.vg straddle-lo.vg
+
+# Two clipped intervals with a clean, fully anchored island between them.  The island is 0%
+# unaligned, so -k has to stop at it: the sequence past it looks unaligned only because it is
+# itself being clipped, and a walk allowed to score that would drag the boundary across it.
+mkgraph nbr.gfa "2:200:1 5:100:0 3:100:1 25:20:0 2:200:1"
+vg convert -g nbr.gfa -p > nbr.vg
+
+clip-vg nbr.vg -f -e REF -a _MINIGRAPH_ -u 400 -k 600 -T 0.15 > nbr-k.vg
+is "$(samp_frags nbr-k.vg)" "0-400 900-1200 1700-2100" "-k stops at a neighbouring clipped interval instead of scoring through it"
+
+rm -f nbr.gfa nbr.vg nbr-k.vg
+
+# Book-ended intervals are disjoint under half-open coordinates and load_bed accepts them.  The
+# merge pass is there to collapse the overlaps -k can create, so it has to leave these alone:
+# merging them would drop a breakpoint and quietly renumber what a plain -b run has always emitted.
+mkgraph abut.gfa "10:100:1"
+vg convert -g abut.gfa -p > abut.vg
+abut_path="$(vg paths -E -x abut.vg 2>/dev/null | awk '$1 ~ /^SAMP/ {print $1}')"
+printf '%s\t150\t250\n%s\t250\t350\n' "$abut_path" "$abut_path" > abut.bed
+
+# -k is what puts the merge pass in play; without it the pass is skipped and this asserts nothing.
+# Every node here is anchored, so no walk extends and the pass sees the two intervals as loaded.
+clip-vg abut.vg -f -e REF -b abut.bed -k 1000 -T 0.25 > abut-b.vg
+is "$(max_node_id abut-b.vg)" "13" "book-ended BED intervals keep the breakpoint they share"
+
+rm -f abut.gfa abut.vg abut.bed abut-b.vg
+
+# load_bed only rejects strict overlaps, so a file can carry an empty, inverted or off-the-end
+# record.  Both walks would repair one into a plausible interval that chop_path then honours,
+# turning a typo into deleted sequence -- and for a wholly off-path record, an abort into silence.
+# -k has to leave anything it cannot reason about exactly as it arrived.
+mkgraph degen.gfa "4:100:1 39:10:0 4:100:1"
+vg convert -g degen.gfa -p > degen.vg
+degen_path="$(vg paths -E -x degen.vg 2>/dev/null | awk '$1 ~ /^SAMP/ {print $1}')"
+
+for rec in "600 600" "700 650" "1190 1300"; do
+    printf '%s\t%s\t%s\n' "$degen_path" ${rec} > degen.bed
+    clip-vg degen.vg -f -e REF -b degen.bed > degen-b.vg 2>/dev/null
+    clip-vg degen.vg -f -e REF -a _MINIGRAPH_ -b degen.bed -k 1000 -T 0.25 > degen-k.vg 2>/dev/null
+    is "$(samp_frags degen-k.vg)" "$(samp_frags degen-b.vg)" "-k leaves a [$rec] BED record alone"
+done
+
+# wholly off the path: master aborts, and -k must not turn that into a clean exit
+printf '%s\t1500\t1600\n' "$degen_path" > degen.bed
+clip-vg degen.vg -f -e REF -b degen.bed > /dev/null 2>&1; degen_rc=$?
+clip-vg degen.vg -f -e REF -a _MINIGRAPH_ -b degen.bed -k 1000 -T 0.25 > /dev/null 2>&1
+is "$?" "$degen_rc" "-k does not convert an off-path BED record into a clean exit"
+
+rm -f degen.gfa degen.vg degen.bed degen-b.vg degen-k.vg
+
+# --- option handling ---------------------------------------------------------------------------
+
+mkgraph opt.gfa "10:100:1"
+vg convert -g opt.gfa -p > opt.vg
+
+# every node scores negative at or above 1, so no flank could ever be trimmed: say so up front
+# rather than run to completion having done nothing
+clip-vg opt.vg -f -e REF -a _MINIGRAPH_ -u 400 -k 1000 -T 1 > /dev/null 2> opt-t1.err
+is "$?" "1" "-T at or above 1 is rejected instead of silently never trimming"
+
+# NaN passes both signbit and >= 1, then makes every score NaN so no comparison against the
+# running maximum is ever true: -k does nothing, exit 0, empty log.  Reject it instead.
+clip-vg opt.vg -f -e REF -a _MINIGRAPH_ -u 400 -k 1000 -T nan > /dev/null 2> opt-nan.err
+is "$?" "1" "-T nan is rejected rather than silently disabling -k"
+
+# 0 is in the documented range and is a coherent request -- extend unconditionally -- but at it an
+# aligned base scores 0 rather than negative, so the walk cannot die and every trim runs to the cap
+clip-vg opt.vg -f -e REF -a _MINIGRAPH_ -u 400 -k 1000 -T 0 > /dev/null 2> opt-t0.err
+is "$(grep -c 'gates nothing' opt-t0.err)" "1" "-T 0 warns that it gates nothing"
+
+# -k needs intervals to act on, but a wrapper may pass it unconditionally and disable with 0,
+# so this warns rather than failing a job that is otherwise fine
+clip-vg opt.vg -f -e REF -k 1000 > /dev/null 2> opt-nosrc.err
+is "$?" "0" "-k without an interval source is not fatal"
+is "$(grep -c 'needs clipped intervals' opt-nosrc.err)" "1" "but it does warn"
+
+rm -f opt.gfa opt.vg opt-t1.err opt-nan.err opt-t0.err opt-nosrc.err


### PR DESCRIPTION
Both aligners work by extending anchors, so an anchor in unique sequence beside a satellite array gets extended into it.  Inside the array the orthologous alignment is undefined -- copies are interchangeable and copy number differs between haplotypes -- so each haplotype takes some arbitrary but locally high-scoring path for a while past the boundary, and the haplotypes disagree. -u clips the runs longer than its threshold; what is left is a tangle at every boundary, in runs too short for -u to reach.

-k walks outward from each clipped interval, scoring each base by whether it is unaligned -- the same test -u itself applies, on a `_MINIGRAPH_` node under -a or visited by another path otherwise -- and cuts at the furthest point of maximal cumulative score.  That is Mott's rule, so the cut lands past a local dip when unaligned sequence resumes beyond it, but a sustained aligned stretch ends the trim.  N caps the reach and is the control that matters: inside a repeat the gate seldom closes on its own.  Measured on a 118-haplotype chrY, 3.4% of edges at 20000, 9.4% at 50000, 29.4% at 200000.

-T sets the density it keeps walking through.  Negative calibrates against the graph, which is the default and what you want: the near-field rate runs 0.10 to 0.45 across 24 human chromosomes and the threshold it implies 0.054 to 0.230, a 4.3x spread tracking neither haplotype count nor chromosome size.  Calibration compares sequence within 5kb of a clipped interval against sequence beyond 200kb and takes the midpoint, and refuses rather than guessing when the two samples are too small, or separated by less than 2x.

An earlier revision gated on node length instead, on the theory that fragmentation is the visible signature of a tangle.  Measured on 460 HPRC haplotypes it removed more edges per base, but its background varied 3% to 22% between chromosomes against 0.36% to 1.28% for this one, and it could disagree with -u about what "unaligned" means.  Consistency won.  Both gates beat no trimming: against dipcall truth over 231 samples, aardvark F1 improves in 231 of 231.

Whole genome, HPRC v2.1 against CHM13: nodes -1.53%, edges -1.98%, length -1.49%, concentrated where it should be -- chrY -9.4% of edges, the acrocentrics next, chr6 -0.1%.