### PR TITLE
Fix -o/--out-bed naming subpaths and reporting them at the wrong offset

### DIFF
--- a/clip-vg.cpp
+++ b/clip-vg.cpp
@@ -73,6 +73,21 @@ static unordered_map<string, vector<pair<int64_t, int64_t>>> get_clipped_interva
     const unordered_map<string, vector<pair<int64_t, int64_t>>>& output_intervals);
 
 // Create a subpath name (todo: make same function in vg consistent (it only includes start))
+// A path's name with any subrange stripped off, so that an input path and the subpaths clipped
+// out of it share a key.  get_path_name() spells the subrange out as "name[start-end]", which would
+// file every output subpath under a key no input path has.
+static inline string strip_subpath_name(const string& path_name) {
+    PathSense sense;
+    string sample;
+    string locus;
+    size_t haplotype;
+    size_t phase_block;
+    subrange_t subrange;
+    PathMetadata::parse_path_name(path_name, sense, sample, locus, haplotype, phase_block, subrange);
+    return PathMetadata::create_path_name(sense, sample, locus, haplotype, phase_block,
+                                          PathMetadata::NO_SUBRANGE);
+}
+
 static inline string make_subpath_name(const string& path_name, size_t offset, size_t length) {
     PathSense sense;
     string sample;
@@ -119,6 +134,8 @@ int main(int argc, char** argv) {
             {"allow-cycle", no_argument, 0, 'c'},
             {"force-clip", no_argument, 0, 'f'},
             {"name-replace", required_argument, 0, 'r'},
+            {"no-orphan-filter", no_argument, 0, 'n'},
+            // the spelling that shipped, kept working so nobody's script breaks
             {"no-orphan_filter", no_argument, 0, 'n'},
             {"drop-prefix", required_argument, 0, 'd'},
             {"leave-aligned", no_argument, 0, 'L'},
@@ -1219,13 +1236,15 @@ void drop_paths(MutablePathMutableHandleGraph* graph, const string& drop_prefix,
 unordered_map<string, vector<pair<int64_t, int64_t>>> get_path_intervals(const PathHandleGraph* graph) {
     unordered_map<string, vector<pair<int64_t, int64_t>>> path_intervals;
     graph->for_each_path_handle([&](path_handle_t path_handle) {
-            string path_name = graph->get_path_name(path_handle);
+            string path_name = strip_subpath_name(graph->get_path_name(path_handle));
             size_t path_len = 0;
             graph->for_each_step_in_path(path_handle, [&](step_handle_t step_handle) {
                     path_len += graph->get_length(graph->get_handle_of_step(step_handle));
                 });
             subrange_t path_range = graph->get_subrange(path_handle);
-            int64_t start = path_range == PathMetadata::NO_SUBRANGE ? 0 : path_range.second;
+            // .first is where the subpath starts; .second is where it ends, and using that put
+            // every subpath's interval a whole path-length to the right of the truth
+            int64_t start = path_range == PathMetadata::NO_SUBRANGE ? 0 : (int64_t)path_range.first;
             vector<pair<int64_t, int64_t>>& intervals = path_intervals[path_name];        
             intervals.push_back(make_pair(start, start + path_len));
         });
@@ -1263,11 +1282,11 @@ static unordered_map<string, vector<pair<int64_t, int64_t>>> get_clipped_interva
             // and nothing overlaps
             int64_t j = 0;
             int64_t k = 0;
-            for (int64_t i = 0; i < in_intervals.size(); ++i) {
+            for (int64_t i = 0; i < (int64_t)in_intervals.size(); ++i) {
                 // j: first out_interval that's not completely left of in_interval;
-                for (; j < out_intervals.size() && out_intervals[j].second < in_intervals[i].first; ++j);
+                for (; j < (int64_t)out_intervals.size() && out_intervals[j].second < in_intervals[i].first; ++j);
                 // k: first out_interval that's completely right of in_interval
-                for (k = j; k < out_intervals.size() && out_intervals[k].first < in_intervals[i].second; ++k);
+                for (k = j; k < (int64_t)out_intervals.size() && out_intervals[k].first < in_intervals[i].second; ++k);
                 // [j, k) all out_intervals that are sub intervals of in_interval[i]
                 vector<pair<int64_t, int64_t>>&  gap_intervals = clipped_intervals[path_name];
                 if (k == j) {
@@ -1278,15 +1297,17 @@ static unordered_map<string, vector<pair<int64_t, int64_t>>> get_clipped_interva
                     if (out_intervals[j].first > in_intervals[i].first) {
                         gap_intervals.push_back(make_pair(in_intervals[i].first, out_intervals[j].first));
                     }
-                    // gaps between out_intervals
-                    for (int64_t l = 0; l < (int64_t)out_intervals.size() - 2; ++l) {
+                    // gaps between the out_intervals that fall inside this in_interval.  Bounded
+                    // by [j, k) rather than the whole vector: stopping at size - 2 dropped the last
+                    // gap, and scanning all of them reported every gap once per in_interval.
+                    for (int64_t l = j; l + 1 < k; ++l) {
                         if (out_intervals[l+1].first > out_intervals[l].second) {
                             gap_intervals.push_back(make_pair(out_intervals[l].second, out_intervals[l+1].first));
                         }
                     }
-                    // right of last interval
-                    if (in_intervals[i].second > out_intervals.back().second) {
-                        gap_intervals.push_back(make_pair(out_intervals.back().second, in_intervals[i].second));
+                    // right of the last interval inside this one
+                    if (in_intervals[i].second > out_intervals[k-1].second) {
+                        gap_intervals.push_back(make_pair(out_intervals[k-1].second, in_intervals[i].second));
                     }
                 }
             }

--- a/tests/t/chop.t
+++ b/tests/t/chop.t
@@ -6,7 +6,7 @@ BASH_TAP_ROOT=./bash-tap
 PATH=..:$PATH
 PATH=../deps/hal/bin:$PATH
 
-plan tests 47
+plan tests 52
 
 # how many steps of a given path still point backwards.  Reports instead of counting if the
 # graph is unusable or the path is missing, so that a crashed run leaving an empty output
@@ -229,3 +229,47 @@ clip-vg nr-rev.vg -e no-such-prefix -u 5 > nr-rev-u.vg 2> nr-rev-u.err
 is "$?" "1" "a mistyped -e with -u fails instead of silently emitting an empty graph"
 
 rm -f nr-rev.vg nr-rev-fwd.vg nr-rev-none.vg nr-rev-none.err nr-rev-u.vg nr-rev-u.err
+
+# --- -o/--out-bed ------------------------------------------------------------------------------
+
+# -o reports what was clipped by diffing the input paths against the output ones, so it has to name
+# the path a subpath came from and give coordinates in that path's space.  Two things were wrong,
+# and neither shows on a graph whose paths carry no subranges -- where the key has no bracket to
+# strip and the offset is 0 either way -- so this clips twice to get a subranged graph first.
+{
+    printf 'H\tVN:Z:1.0\n'
+    for i in $(seq 12); do printf 'S\t%s\tACGTACGTAC\n' "$i"; done
+    for i in $(seq 11); do printf 'L\t%s\t+\t%s\t+\t0M\n' "$i" "$((i+1))"; done
+    seg="$(seq 12 | sed 's/$/+/' | paste -sd,)"
+    printf 'P\tREF#0#chr1\t%s\t*\n' "$seg"
+    printf 'P\tSAMP#0#chr1\t%s\t*\n' "$seg"
+    printf 'P\t_MINIGRAPH_#0#a\t1+,2+\t*\n'
+    printf 'P\t_MINIGRAPH_#0#b\t11+,12+\t*\n'
+} > outbed.gfa
+vg convert -g outbed.gfa -p > outbed.vg
+
+# nodes 3-10 are off the minigraph, so -u 50 clips the middle and leaves SAMP as two subpaths
+# carrying subranges: [0-20] and [100-120]
+clip-vg outbed.vg -f -e REF -a _MINIGRAPH_ -u 50 > outbed-sub.vg
+is "$(vg paths -L -x outbed-sub.vg 2>/dev/null | grep -c '^SAMP.*\[')" "2" "the first clip leaves subpaths carrying subranges"
+
+# now clip those away and report it.  -m clips whole paths, so the two intervals are exactly the
+# two subranges, and the BED must say so.
+clip-vg outbed-sub.vg -f -e REF -m 25 -o outbed.bed > outbed-clipped.vg
+
+# get_path_name() spells the subrange out as "name[start-end]", which files the record under a key
+# no input path has and no downstream consumer can join on
+is "$(grep -c '\[' outbed.bed)" "0" "-o names the path a subpath came from, not the subpath"
+
+# the offset came from subrange.second -- where the subpath ends -- rather than .first, which put
+# every interval a whole path-length to the right of the truth (20 40 / 120 140 here)
+is "$(awk '$1 ~ /^SAMP/ {print $2"-"$3}' outbed.bed | sort -t- -k1,1n | tr '\n' ' ' | sed 's/ *$//')" \
+   "0-20 100-120" "-o reports subpath intervals in the coordinates of the path they came from"
+
+# the help has always advertised --no-orphan-filter; only --no-orphan_filter was ever wired up
+clip-vg outbed.vg -f -e REF -a _MINIGRAPH_ -u 50 --no-orphan-filter > /dev/null 2>&1
+is "$?" "0" "the --no-orphan-filter spelling the help documents is accepted"
+clip-vg outbed.vg -f -e REF -a _MINIGRAPH_ -u 50 --no-orphan_filter > /dev/null 2>&1
+is "$?" "0" "and the --no-orphan_filter spelling that shipped still works"
+
+rm -f outbed.gfa outbed.vg outbed-sub.vg outbed.bed outbed-clipped.vg


### PR DESCRIPTION
-o reports what was clipped by diffing the input paths against the output ones, so it has to match an output subpath back to the path it came from and give coordinates in that path's space.  Both halves were wrong on any graph whose paths already carry subranges, which is every graph that has been clipped once already:

get_path_name() spells a subrange out as "name[start-end]", and that string was used as the map key, so every record was filed under a name no input path has and nothing downstream could join on it.  And the offset came from subrange.second -- where the subpath ends -- rather than .first, which put every interval a whole path-length to the right of the truth.

On a real minigraph-cactus graph master emitted 231 lines covering 1,640,106bp of nothing; this emits 418 lines and 70,135bp, matching a bedtools-computed ground truth exactly.  Neither fault is visible on a graph with no subranges, where the key has no bracket to strip and the offset is 0 either way, so the test clips twice to get a subranged graph before reporting on it.

Also wires up --no-orphan-filter.  The help has advertised that spelling all along; only --no-orphan_filter was ever in the option table.